### PR TITLE
TELECOM-7008: Fix a dangling else

### DIFF
--- a/dprint.h
+++ b/dprint.h
@@ -261,9 +261,9 @@ static inline char* dp_time(void)
 		#define LM_GEN2( _facility, _lev, ...) \
 			do { \
 				if (is_printable(_lev)){ \
-					if (log_stderr) \
-						if (log_stderr) dprint(__VA_ARGS__); \
-					else { \
+					if (log_stderr) { \
+						dprint(__VA_ARGS__); \
+					} else { \
 						switch(_lev){ \
 							case L_CRIT: \
 								syslog(LOG_CRIT|_facility, __VA_ARGS__); \
@@ -452,9 +452,9 @@ static inline char* dp_time(void)
 		#define LM_GEN2( _facility, _lev, fmt, args...) \
 			do { \
 				if (is_printable(_lev)){ \
-					if (log_stderr) \
-						if (log_stderr) dprint( fmt, ## args); \
-					else { \
+					if (log_stderr) { \
+						dprint( fmt, ## args); \
+					} else { \
 						switch(_lev){ \
 							case L_CRIT: \
 								syslog(LOG_CRIT|_facility, fmt, ##args); \


### PR DESCRIPTION
Currently, CI failing due to the below `dangling-else` warning.
```
route_struct.c: In function ‘print_expr’:
parser/../dprint.h:455:9: error: suggest explicit braces to avoid ambiguous ‘else’ [-Werror=dangling-else]
  455 |      if (log_stderr) \
      |         ^
[...]
cc1: all warnings being treated as errors
make: *** [route_struct.o] Error 1
Makefile.rules:29: recipe for target 'route_struct.o' failed
Error: Process completed with exit code 2.
```