### PR TITLE
TELECOM-7814: Add a core script function to terminate OpenSIPS-tracked TCP connections

### DIFF
--- a/core_cmds.c
+++ b/core_cmds.c
@@ -40,6 +40,7 @@
 #include "msg_translator.h"
 /* needed by tcpconn_add_alias() */
 #include "net/tcp_conn_defs.h"
+#include "net/net_tcp.h"
 
 static int fixup_forward_dest(void** param);
 static int fixup_destination(void** param);
@@ -92,6 +93,7 @@ static int w_force_tcp_alias(struct sip_msg *msg, int *port);
 static int w_set_adv_address(struct sip_msg *msg, str *adv_addr);
 static int w_set_adv_port(struct sip_msg *msg, str *adv_port);
 static int w_f_send_sock(struct sip_msg *msg, struct socket_info *si);
+static int w_f_close_tcp_sock(struct sip_msg *msg, str *host, int *port);
 static int w_serialize_branches(struct sip_msg *msg, int *clear_prev,
 					int *keep_ord);
 static int w_next_branches(struct sip_msg *msg);
@@ -238,6 +240,10 @@ static cmd_export_t core_cmds[]={
 		ALL_ROUTES},
 	{"force_send_socket", (cmd_function)w_f_send_sock, {
 		{CMD_PARAM_STR, fixup_f_send_sock, 0}, {0,0,0}},
+		ALL_ROUTES},
+	{"force_close_tcp_socket", (cmd_function)w_f_close_tcp_sock, {
+		{CMD_PARAM_STR, 0, 0},
+		{CMD_PARAM_INT, 0, 0}, {0,0,0}},
 		ALL_ROUTES},
 	{"serialize_branches", (cmd_function)w_serialize_branches, {
 		{CMD_PARAM_INT, 0, 0},
@@ -950,6 +956,38 @@ static int w_f_send_sock(struct sip_msg *msg, struct socket_info *si)
 
 	return 1;
 }
+
+static int w_f_close_tcp_sock(struct sip_msg *msg, str *host, int *port)
+{
+	int fd, n, i, closed_no = 0;
+	struct hostent *he;
+	struct ip_addr ip;
+	struct tcp_connection *c;
+
+	he = resolvehost(host->s, 0);
+	if (he == 0) {
+		LM_ERR("could not resolve host\n");
+		return E_BAD_ADDRESS;
+	}
+
+	for (i = 0; he->h_addr_list[i]; ++i) {
+		hostent2ip_addr(&ip, he, i);
+		n = tcp_conn_get(0, &ip, *port, PROTO_TCP, NULL, &c, &fd, NULL);
+		if (n < 0 || c == 0) continue;
+		shutdown(fd, SHUT_RDWR);
+		c->state = S_CONN_BAD;
+		tcp_conn_release(c, 0);
+		closed_no += 1;
+	}
+
+	if (closed_no == 0) {
+		LM_WARN("TCP connection not found\n");
+		return -1;
+	}
+	LM_DBG("TCP connection force closed\n");
+	return 1;
+}
+
 
 static int w_serialize_branches(struct sip_msg *msg, int *clear_prev,
 							int *keep_ord)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
In order to consider and evaluate your PR, it is mandatory to provide detailed information about (1) what is the issue the PR addresses, (2) how the PR is solving the issue (logic and coding), (3) what are (if any) limitations of the proposed PR and (4) if there are any known side-effects/ backward compatibility issues/SIP interoperability issues.
Note that if the PR is missing information, it might take longer to be merged, as extra resources have to be allocated by the maintainers to reverse engineer the changes, understand them, understand the motivation, etc. That is why it is important to provide as much information as possible.
-->

**Summary**
<!-- Summary of the PR - what the PR is aiming to solve -->
This PR adds a core script function to terminate OpenSIPS-tracked TCP connections by endpoint address.

Interface:
```
force_close_tcp_socket(host, port);
```
`host` (string): remote hostname or IP.
`port` (integer): remote port.

**Details**
<!--
Details about the content of the PR - is it a bug fix, a new feature or perhaps a hack? Explain the **motivation** for making this change.
What existing problem does the pull request solve? Is this a particular problem (i.e. only some particular scenarios are affected, only some UACs, etc) or a generic one?
Do not assume others understand what you're trying to do and provide as much information as you may have.
-->
***Example***
OpenSIPS script:

```
mpath="/usr/local/lib64/opensips/modules"

log_level = 4
log_level = 4
tcp_workers = 1
socket = tcp:127.0.0.1:5060

loadmodule "proto_tcp.so"

timer_route[test, 5] {
    force_close_tcp_socket("localhost", 5555);
}
```

New connections with peer address `127.0.0.1:5555` will dropped in ~5 sec:
```sh
ncat -vvvv -p 5555 127.0.0.1 5060
```

**Solution**
<!-- Explain how your PR fixes the problem. Are there any remaining concerns that might need to be addressed? -->
Other interface syntax ideas:
- `force_close_tcp_socket("localhost:5555");`
- `force_close_socket("tcp:localhost:5555");`

**Compatibility**
<!-- Does your change break other scenarios, or do they need to be migrated in order to work similarly? -->
The feature tested with `3.2` and `master`.

**Closing issues**
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
N/A