### PR TITLE
TELECOM-7937: Fix qop-value for MD5 hashing

### DIFF
--- a/modules/uac_auth/auth.c
+++ b/modules/uac_auth/auth.c
@@ -240,6 +240,7 @@ int do_uac_auth(str *msg_body, str *method, str *uri, struct uac_credential *crd
 	const struct digest_auth_calc *digest_calc;
 	str_const cnonce;
 	str_const nc;
+	str_const qop;
 
 	digest_calc = get_digest_calc(auth->algorithm);
 	if (digest_calc == NULL) {
@@ -285,8 +286,13 @@ int do_uac_auth(str *msg_body, str *method, str *uri, struct uac_credential *crd
 		    !(auth->flags&QOP_AUTH), &ha2) != 0)
 			return (-1);
 
+		if (auth->flags & QOP_AUTH) {
+			qop = str_const_init(QOP_AUTH_STR);
+		} else {
+			qop = str_const_init(QOP_AUTHINT_STR);
+		}
 		if (digest_calc->response(&ha1, &ha2, str2const(&auth->nonce),
-		    str2const(&auth->qop), &nc, &cnonce, response) != 0)
+		    &qop, &nc, &cnonce, response) != 0)
 			return (-1);
 		auth_nc_cnonce->nc = nc;
 		auth_nc_cnonce->cnonce = cnonce;


### PR DESCRIPTION
We are experiencing regression in the result values of the digest authentication response when the qop value is set to `auth,auth-int` and the MD5 hashing algorithm is being used.

According to the documentation, the `uac_auth` module supports both qop values of `auth` and `auth-int`, but when both values are presented, `auth` is preferred. (Source: https://opensips.org/html/docs/modules/3.2.x/uac_auth.html)

We have identified that the qop value is being filled with `auth,auth-int` for hashing instead of `auth` as described in RFC2617. The parsing set the qop flag correctly, but keeps the original qop value and using that later for hashing which causing the issue.

This is a temporary hotfix and will be reverted when we have an official solution.