### PR TITLE
TELECOM-6970: Add support to bypass the anycast check for TM replication

### DIFF
--- a/modules/tm/cluster.c
+++ b/modules/tm/cluster.c
@@ -27,6 +27,7 @@
 #include "../../bin_interface.h"
 #include "../../parser/parse_cseq.h"
 
+int tm_bypass_anycast_check = 0;
 str tm_cid;
 int tm_repl_cluster = 0;
 int tm_repl_auto_cancel = 1;
@@ -184,20 +185,25 @@ static void receive_tm_repl(bin_packet_t *packet)
 	TM_BIN_POP(str, &tmp, "dst host");
 	TM_BIN_POP(int, &port, "dst port");
 
-	ri.bind_address = grep_internal_sock_info(&tmp, port, proto);
-	if (!ri.bind_address) {
-		LM_WARN("received replicated message for an interface"
-				" we don't know %s:%.*s:%d; discarding...\n",
-				proto2a(proto), tmp.len, tmp.s, port);
-		return;
+	if (!tm_bypass_anycast_check) {
+		ri.bind_address = grep_internal_sock_info(&tmp, port, proto);
+		if (!ri.bind_address) {
+			LM_WARN("received replicated message for an interface"
+					" we don't know %s:%.*s:%d; discarding...\n",
+					proto2a(proto), tmp.len, tmp.s, port);
+			return;
+		}
+		if (!(ri.bind_address->flags & SI_IS_ANYCAST)) {
+			LM_WARN("received replicated message for a non-anycast interface"
+					" %s:%.*s:%d\n",
+					proto2a(proto), tmp.len, tmp.s, port);
+		}
+		ri.dst_port = ri.bind_address->port_no;
+		ri.dst_ip = ri.bind_address->address;
+		ri.dst_port = ri.bind_address->port_no;
+		ri.dst_ip = ri.bind_address->address;
 	}
-	if (!(ri.bind_address->flags & SI_IS_ANYCAST)) {
-		LM_WARN("received replicated message for a non-anycast interface"
-				" %s:%.*s:%d\n",
-				proto2a(proto), tmp.len, tmp.s, port);
-	}
-	ri.dst_port = ri.bind_address->port_no;
-	ri.dst_ip = ri.bind_address->address;
+	
 	ri.proto = proto;
 	/* XXX: do we care about this? Only UDP should work with anycast */
 	ri.proto_reserved1 = ri.proto_reserved2 = 0;
@@ -473,8 +479,8 @@ int tm_reply_replicate(struct sip_msg *msg)
 	if (!tm_cluster_enabled())
 		return 0;
 
-	/* double-check we have received the message on a anycast network */
-	if (!is_anycast(msg->rcv.bind_address))
+	/* check if the anycast bypass is active, if not double-check we have received the message on a anycast network*/
+	if (!tm_bypass_anycast_check && !is_anycast(msg->rcv.bind_address))
 		return 0;
 	cid = tm_get_cid(msg);
 	/* if there was no parameter, or it was, but it was ours, handle it */

--- a/modules/tm/cluster.h
+++ b/modules/tm/cluster.h
@@ -30,6 +30,7 @@
 #define TM_CLUSTER_VERSION 0
 #define TM_CLUSTER_DEFAULT_PARAM "cid"
 
+extern int tm_bypass_anycast_check;
 extern int tm_repl_cluster;
 extern int tm_repl_auto_cancel;
 extern str tm_cluster_param;

--- a/modules/tm/tm.c
+++ b/modules/tm/tm.c
@@ -314,6 +314,8 @@ static param_export_t params[]={
 		&tm_cluster_param.s },
 	{ "cluster_auto_cancel",      INT_PARAM,
 		&tm_repl_auto_cancel },
+	{ "bypass_anycast_check",     INT_PARAM,
+        &tm_bypass_anycast_check },
 	{0,0,0}
 };
 


### PR DESCRIPTION
Adding support to bypass the anycast check using a modparam