### PR TITLE
TELECOM-9136: Fix HEP reconnect

### DIFF
--- a/modules/proto_hep/proto_hep.c
+++ b/modules/proto_hep/proto_hep.c
@@ -420,10 +420,7 @@ static int hep_tcp_or_tls_send(struct socket_info* send_sock,
 		return -1;
 	}
 
-	if (is_connection_max_lifetime_exceeded(c)) {
-		tcp_conn_destroy(c);
-		c = NULL;
-	}
+	if (is_connection_max_lifetime_exceeded(c)) c->do_not_reuse = 1;
 
 	/* was connection found ?? */
 	if (c == 0) {
@@ -499,6 +496,7 @@ static int hep_tcp_or_tls_send(struct socket_info* send_sock,
 			return -1;
 		}
 		c->first_seen = time(0);
+		c->do_not_reuse = 0;
 		goto send_it;
 	}
 
@@ -547,7 +545,11 @@ send_it:
 			hep_send_timeout, hep_async_local_write_timeout);
 	}
 
-	tcp_conn_set_lifetime(c, tcp_con_lifetime);
+	if (c->do_not_reuse) {
+		c->lifetime = get_ticks() - 1;
+	} else {
+		tcp_conn_set_lifetime(c, tcp_con_lifetime);
+	}
 
 	LM_DBG("after write: c= %p n/len=%d/%d fd=%d\n", c, n, len, fd);
 	/* LM_DBG("buf=\n%.*s\n", (int)len, buf); */

--- a/net/net_tcp.c
+++ b/net/net_tcp.c
@@ -489,6 +489,13 @@ int tcp_conn_get(unsigned int id, struct ip_addr* ip, int port,
 	return 0;
 
 found:
+	if (c->do_not_reuse) {
+		*conn = NULL;
+		if (conn_fd) *conn_fd = -1;
+		TCPCONN_UNLOCK(part);
+		return 0;
+	}
+
 	c->refcnt++;
 	TCPCONN_UNLOCK(part);
 	sh_log(c->hist, TCP_REF, "tcp_conn_get, (%d)", c->refcnt);

--- a/net/tcp_conn_defs.h
+++ b/net/tcp_conn_defs.h
@@ -156,6 +156,7 @@ struct tcp_connection{
 	/* protocol specific data attached to this connection */
 	void *proto_data;
 	time_t first_seen;
+	int do_not_reuse;
 };
 
 


### PR DESCRIPTION
The main idea was to add HEP TCP/TLS periodic reconnect functionality without modifying the OpenSIPS internal TCP connection management code to eliminate the possibility of side effects on connections other than HEP TCP/TLS. After extensive investigation, I found no way to achieve this (without crashes, or missing HEP traces). Therefore, in this solution proposal, I chose a middle path where I modified the OpenSIPS internal TCP management logic. However, I ensured that the modifications only have an impact on HEP TCP and TLS connections.

Instead of directly closing the connection after the time limit is reached, I let the old connection timeout and shutdown gracefully. To achieve this, I introduced a new flag to the connection, indicating that when we try to retrieve a connection for reuse, don’t return a connection that is flagged. Because the connection is not reused, it will hit timeout and shutdown gracefully. Additionally, I decreased the timeout for flagged connections, so that we don’t have to wait for the entire timeout cycle before cleaning up the connection. This way if anything remains unsent and is buffered, it will be sent out before OpenSIPS gracefully terminate the connection (if the connection is healthy).

Also, note that I should be able to “fix” the TCP connection reuse interface to not return connections whose lifetime has expired, but that would have an impact on every TCP connection managed by OpenSIPS. In the interest of stability, I instead introduced the extra flag.

(After OpenSIPS 3.3, the reconnect functionality should be considered for implementation in tcp_mgm instead of here. It would serve as a general TCP reconnect function to merge with the upstream where we can make the correct moves and can cleanup this extra flag.)