### PR TITLE
Remove `xlog(...)` prefix temporarily

### DIFF
--- a/dprint.h
+++ b/dprint.h
@@ -247,6 +247,19 @@ static inline char *dp_log_level_str(int log_level)
 	#define __DP_FUNC  ((__const char *) 0)
 #endif
 
+// Macro to enable/disable the warning for format specifier
+#if defined(__clang__)
+    #define DISABLE_FORMAT_WARNING _Pragma("clang diagnostic push") \
+                                   _Pragma("clang diagnostic ignored \"-Wformat\"")
+    #define ENABLE_FORMAT_WARNING  _Pragma("clang diagnostic pop")
+#elif defined(__GNUC__)
+    #define DISABLE_FORMAT_WARNING _Pragma("GCC diagnostic push") \
+                                   _Pragma("GCC diagnostic ignored \"-Wformat\"")
+    #define ENABLE_FORMAT_WARNING  _Pragma("GCC diagnostic pop")
+#else
+    #define DISABLE_FORMAT_WARNING
+    #define ENABLE_FORMAT_WARNING
+#endif
 
 #ifdef NO_LOG
 
@@ -340,49 +353,27 @@ static inline char *dp_log_level_str(int log_level)
 		#define LM_GEN2( _facility, _lev, fmt, ...) \
 			do { \
 				if (is_printable(_lev)){ \
+					DISABLE_FORMAT_WARNING; \
 					switch(_lev){ \
 					case L_CRIT: \
-						dprint(_lev, _facility, NULL, NULL, \
-							DP_CRIT_PREFIX fmt, "%s" DP_CRIT_TEXT fmt, fmt, \
-							dp_time(), dp_my_pid(), log_prefix __VA_ARGS__) \
-						break; \
 					case L_ALERT: \
-						dprint(_lev, _facility, NULL, NULL, \
-							DP_ALERT_PREFIX fmt, "%s" DP_ALERT_TEXT fmt, fmt, \
-							dp_time(), dp_my_pid(), log_prefix __VA_ARGS__) \
-						break; \
 					case L_ERR: \
-						dprint(_lev, _facility, NULL, NULL, \
-							DP_ERR_PREFIX fmt, "%s" DP_ERR_TEXT fmt, fmt, \
-							dp_time(), dp_my_pid(), log_prefix __VA_ARGS__) \
-						break; \
 					case L_WARN: \
-						dprint(_lev, _facility, NULL, NULL, \
-							DP_WARN_PREFIX fmt, "%s" DP_WARN_TEXT fmt, fmt, \
-							dp_time(), dp_my_pid(), log_prefix __VA_ARGS__) \
-						break; \
 					case L_NOTICE: \
-						dprint(_lev, _facility, NULL, NULL, \
-							DP_NOTICE_PREFIX fmt, "%s" DP_NOTICE_TEXT fmt, fmt, \
-							dp_time(), dp_my_pid(), log_prefix __VA_ARGS__) \
-						break; \
 					case L_INFO: \
-						dprint(_lev, _facility, NULL, NULL, \
-							DP_INFO_PREFIX fmt, "%s" DP_INFO_TEXT fmt, fmt, \
-							dp_time(), dp_my_pid(), log_prefix __VA_ARGS__) \
-						break; \
 					case L_DBG: \
 						dprint(_lev, _facility, NULL, NULL, \
-							DP_DBG_PREFIX fmt, "%s" DP_DBG_TEXT fmt, fmt, \
-							dp_time(), dp_my_pid(), log_prefix __VA_ARGS__) \
+							"%.0s%.0s%.0s" fmt, "%.0s" fmt, fmt, \
+							dp_time(), dp_my_pid(), log_prefix __VA_ARGS__); \
 						break; \
 					default: \
 						if (_lev > L_DBG) \
 							dprint(_lev, _facility, NULL, NULL, \
-								DP_DBG_PREFIX fmt, "%s" DP_DBG_TEXT fmt, fmt, \
-								dp_time(), dp_my_pid(), log_prefix __VA_ARGS__) \
+								"%.0s%.0s%.0s" fmt, "%.0s" fmt, fmt, \
+								dp_time(), dp_my_pid(), log_prefix __VA_ARGS__); \
 						break; \
 					} \
+					ENABLE_FORMAT_WARNING; \
 				} \
 			}while(0)
 
@@ -505,49 +496,27 @@ static inline char *dp_log_level_str(int log_level)
 		#define LM_GEN2( _facility, _lev, fmt, args...) \
 			do { \
 				if (is_printable(_lev)){ \
+					DISABLE_FORMAT_WARNING; \
 					switch(_lev){ \
 					case L_CRIT: \
-						dprint(_lev, _facility, NULL, NULL, \
-							DP_CRIT_PREFIX fmt, "%s" DP_CRIT_TEXT fmt, fmt, \
-							dp_time(), dp_my_pid(), log_prefix, ## args); \
-						break; \
 					case L_ALERT: \
-						dprint(_lev, _facility, NULL, NULL, \
-							DP_ALERT_PREFIX fmt, "%s" DP_ALERT_TEXT fmt, fmt, \
-							dp_time(), dp_my_pid(), log_prefix, ## args); \
-						break; \
 					case L_ERR: \
-						dprint(_lev, _facility, NULL, NULL, \
-							DP_ERR_PREFIX fmt, "%s" DP_ERR_TEXT fmt, fmt, \
-							dp_time(), dp_my_pid(), log_prefix, ## args); \
-						break; \
 					case L_WARN: \
-						dprint(_lev, _facility, NULL, NULL, \
-							DP_WARN_PREFIX fmt, "%s" DP_WARN_TEXT fmt, fmt, \
-							dp_time(), dp_my_pid(), log_prefix, ## args); \
-						break; \
 					case L_NOTICE: \
-						dprint(_lev, _facility, NULL, NULL, \
-							DP_NOTICE_PREFIX fmt, "%s" DP_NOTICE_TEXT fmt, fmt, \
-							dp_time(), dp_my_pid(), log_prefix, ## args); \
-						break; \
 					case L_INFO: \
-						dprint(_lev, _facility, NULL, NULL, \
-							DP_INFO_PREFIX fmt, "%s" DP_INFO_TEXT fmt, fmt, \
-							dp_time(), dp_my_pid(), log_prefix, ## args); \
-						break; \
 					case L_DBG: \
 						dprint(_lev, _facility, NULL, NULL, \
-							DP_DBG_PREFIX fmt, "%s" DP_DBG_TEXT fmt, fmt, \
+							"%.0s%.0s%.0s" fmt, "%.0s" fmt, fmt, \
 							dp_time(), dp_my_pid(), log_prefix, ## args); \
 						break; \
 					default: \
 						if (_lev > L_DBG) \
 							dprint(_lev, _facility, NULL, NULL, \
-							DP_DBG_PREFIX fmt, "%s" DP_DBG_TEXT fmt, fmt, \
+							"%.0s%.0s%.0s" fmt, "%.0s" fmt, fmt, \
 							dp_time(), dp_my_pid(), log_prefix, ## args); \
 						break; \
 					} \
+					ENABLE_FORMAT_WARNING; \
 				} \
 			}while(0)
 


### PR DESCRIPTION
Removed prefix: date, time, PID, loglevel and custom prefix.