### PR TITLE
TELECOM-10237: Bypass the self socket check as the tgrp appended to t…

### DIFF
--- a/modules/topology_hiding/topo_hiding_logic.c
+++ b/modules/topology_hiding/topo_hiding_logic.c
@@ -35,6 +35,7 @@ extern str topo_hiding_seed;
 extern str topo_hiding_ct_encode_pw;
 extern str th_contact_encode_param;
 extern int th_ct_enc_scheme;
+extern int th_bypass_self_check;
 
 struct th_ct_params {
 	str param_name;
@@ -143,7 +144,7 @@ int topology_hiding_match(struct sip_msg *msg)
 
 	r_uri = &msg->parsed_uri;
 
-	if (check_self(&r_uri->host,r_uri->port_no ? r_uri->port_no : SIP_PORT, 0) == 1 && msg->route == NULL) {
+	if ((th_bypass_self_check || check_self(&r_uri->host,r_uri->port_no ? r_uri->port_no : SIP_PORT, 0) == 1) && msg->route == NULL) {
 		/* Seems we are in the topo hiding case :
 		 * we are in the R-URI and there are no other route headers */
 		for (i=0;i<r_uri->u_params_no;i++)

--- a/modules/topology_hiding/topology_hiding.c
+++ b/modules/topology_hiding/topology_hiding.c
@@ -41,6 +41,7 @@ str topo_hiding_seed = str_init("OpenSIPS");
 str topo_hiding_ct_encode_pw = str_init("ToPoCtPaSS");
 str th_contact_encode_param = str_init("thinfo");
 str th_contact_encode_scheme = str_init("base64");
+int th_bypass_self_check = 0;
 
 int th_ct_enc_scheme;
 
@@ -70,7 +71,8 @@ static const param_export_t params[] = {
 	{ "th_callid_prefix",            STR_PARAM, &topo_hiding_prefix.s        },
 	{ "th_contact_encode_passwd",    STR_PARAM, &topo_hiding_ct_encode_pw.s  },
 	{ "th_contact_encode_param",     STR_PARAM, &th_contact_encode_param.s   },
-	{ "th_contact_encode_scheme",    STR_PARAM, &th_contact_encode_scheme.s   },
+	{ "th_contact_encode_scheme",    STR_PARAM, &th_contact_encode_scheme.s  },
+	{ "th_bypass_self_check",        INT_PARAM, &th_bypass_self_check        },
 	{0, 0, 0}
 };
 


### PR DESCRIPTION
When using the topology_hiding module with transaction only, the topology_hiding_match function will never work when using set_advertised_address this is because when a request comes in and the match function is called it makes sure that the host in the request domain matches one of the sockets we are listening on, due to the nature of the change where we now use the local_trunk_identifier prepended to the DNS address byoc.use1.genesys.cloud we will not be advertising our address or putting socket aliases but rather changing the advertised address on a message by message basis and this causes sequentials to fail the topology_hiding_match, this bypasses this check and the topology_hiding_match now matches on the thinfo param only