### PR TITLE
TELECOM-10394: Add subnet mask matching to sockets

### DIFF
--- a/cfg.lex
+++ b/cfg.lex
@@ -321,6 +321,7 @@ QUOTES		\"
 TICK		\'
 SLASH		"/"
 AS			{EAT_ABLE}("as"|"AS"){EAT_ABLE}
+SUBNET_MASK {EAT_ABLE}("subnet_mask"|"SUBNET_MASK"){EAT_ABLE}
 USE_WORKERS	{EAT_ABLE}("use_workers"|"USE_WORKERS"){EAT_ABLE}
 USE_AUTO_SCALING_PROFILE {EAT_ABLE}("use_auto_scaling_profile"|"USE_AUTO_SCALING_PROFILE"){EAT_ABLE}
 SCALE_UP_TO		{EAT_ABLE}("scale"|"SCALE"){EAT_ABLE}+("up"|"UP"){EAT_ABLE}+("to"|"TO"){EAT_ABLE}
@@ -604,6 +605,7 @@ SPACE		[ ]
 
 <INITIAL>{COMMA}		{ count(); return COMMA; }
 <INITIAL>{SEMICOLON}	{ count(); return SEMICOLON; }
+<INITIAL>{SUBNET_MASK}  { count(); return SUBNET_MASK; }
 <INITIAL>{USE_WORKERS}  { count(); return USE_WORKERS; }
 <INITIAL>{USE_AUTO_SCALING_PROFILE}  { count(); return USE_AUTO_SCALING_PROFILE; }
 <INITIAL>{COLON}	{ count(); return COLON; }

--- a/ip_addr.h
+++ b/ip_addr.h
@@ -122,6 +122,7 @@ struct socket_id {
 	int proto;
 	int port;
 	int workers;
+	int subnet_mask;
 	enum si_flags flags;
 	struct socket_id* next;
 };

--- a/modules/topology_hiding/topo_hiding_logic.c
+++ b/modules/topology_hiding/topo_hiding_logic.c
@@ -25,6 +25,7 @@
 */
 
 #include "topo_hiding_logic.h"
+#include "../../socket_info.h"
 
 extern int force_dialog;
 extern struct tm_binds tm_api;
@@ -143,7 +144,9 @@ int topology_hiding_match(struct sip_msg *msg)
 
 	r_uri = &msg->parsed_uri;
 
-	if (check_self(&r_uri->host,r_uri->port_no ? r_uri->port_no : SIP_PORT, 0) == 1 && msg->route == NULL) {
+	if ((find_si_matching_subnet(&r_uri->host, 0) != 0 || 
+		check_self(&r_uri->host,r_uri->port_no ? r_uri->port_no : SIP_PORT, 0) == 1) 
+		&& msg->route == NULL) {
 		/* Seems we are in the topo hiding case :
 		 * we are in the R-URI and there are no other route headers */
 		for (i=0;i<r_uri->u_params_no;i++)

--- a/socket_info.c
+++ b/socket_info.c
@@ -134,6 +134,10 @@ static struct socket_info* new_sock_info( struct socket_id *sid)
 	si->proto=sid->proto;
 	si->flags=sid->flags;
 
+	if (sid->subnet_mask) {
+		si->subnet_mask = sid->subnet_mask;
+	}
+
 	/* advertised socket information */
 	/* Make sure the adv_sock_string is initialized, because if there is
 	 * no adv_sock_name, no other code will initialize it!
@@ -214,6 +218,7 @@ static void free_sock_info(struct socket_info* si)
 		if(si->adv_port_str.s) pkg_free(si->adv_port_str.s);
 		if(si->adv_sock_str.s) pkg_free(si->adv_sock_str.s);
 		if(si->tag_sock_str.s) pkg_free(si->tag_sock_str.s);
+		if(si->subnet) pkg_free(si->subnet);
 	}
 }
 
@@ -235,6 +240,7 @@ struct socket_info* grep_sock_info_ext(str* host, unsigned short port,
 	struct socket_info** list;
 	unsigned short c_proto;
 	struct ip_addr* ip6;
+	struct ip_addr* ip4;
 
 	h_len=host->len;
 	hname=host->s;
@@ -332,7 +338,52 @@ found:
 	return si;
 }
 
+struct socket_info* find_si_matching_subnet(str* host, unsigned short proto) {
+	struct socket_info* si;
+	struct socket_info** list;
+	unsigned short c_proto;
+	struct ip_addr* ip6;
+	struct ip_addr* ip4;
+	struct ip_addr* ip;
 
+	c_proto=proto?proto:PROTO_UDP;
+	do {
+		list=get_sock_info_list(c_proto);
+
+		if (list==0){
+			LM_WARN("unknown proto %d\n", c_proto);
+			goto not_found; /* false */
+		}
+
+		for (si=*list; si; si=si->next) {
+			ip4 = str2ip(host);
+			if (ip4) {
+				ip = ip4;
+			} else {
+				ip6 = str2ip6(host);
+				ip = ip6;
+
+				if (ip6 == 0) continue;
+			} 
+
+			if (si->subnet) {
+				LM_DBG("Subnet for address found '%s'\n", si->address_str.s);
+				if (matchnet(ip, si->subnet) == 1) {
+					goto found;
+				} else {
+					LM_DBG("Subnet not matched '%s' with mask '%d' not matched on host '%s'\n", 
+							si->address_str.s, si->subnet_mask, host->s);
+				}
+			} else {
+				LM_DBG("No subnet for address '%s'\n", si->address_str.s);
+			}
+		}
+	}while( (proto==0) && (c_proto=next_proto(c_proto)) );
+not_found:
+	return 0;
+found:
+	return si;
+}
 
 /* checks if the proto: ip:port is one of the address we listen on
  * and returns the corresponding socket_info structure.
@@ -696,6 +747,16 @@ int fix_socket_list(struct socket_info **list)
 			memcpy(si->address_str.s, tmp, strlen(tmp)+1);
 			si->address_str.len=strlen(tmp);
 		}
+
+		if (si->subnet_mask > 0) {
+			si->subnet = mk_net_bitlen(&si->address, si->subnet_mask);
+			if (si->subnet == 0) {
+				LM_ERR("Failed to add subnet mask '%d 'to socket '%s'\n", si->subnet_mask, si->address_str.s);
+				goto error;
+			}
+			LM_DBG("Added subnet mask '%d 'to socket '%s'\n", si->subnet_mask, si->address_str.s);
+		}
+
 		/* set is_ip (1 if name is an ip address, 0 otherwise) */
 		if ( auto_aliases && (si->address_str.len==si->name.len) &&
 				(strncasecmp(si->address_str.s, si->name.s,

--- a/socket_info.h
+++ b/socket_info.h
@@ -56,7 +56,10 @@ struct socket_info {
 	struct ip_addr adv_address; /* Advertised address in ip_addr form (for find_si) */
 	unsigned short adv_port;    /* optimization for grep_sock_info() */
 	unsigned short workers;
+	unsigned short subnet_mask;
 	struct scaling_profile *s_profile;
+
+	struct net* subnet;
 
 	/* these are IP-level local/remote ports used during the last write op via
 	 * this sock (or a connection belonging to this sock). These values are 
@@ -144,6 +147,8 @@ void print_aliases();
 
 struct socket_info* grep_sock_info_ext(str* host, unsigned short port,
 										unsigned short proto, int check_tag);
+
+struct socket_info* find_si_matching_subnet(str* host, unsigned short proto);
 
 struct socket_info* parse_sock_info(str *spec);
 


### PR DESCRIPTION
A regression was introduced in this PR in sipproxy-v2 https://bitbucket.org/inindca/sipproxy-v2/pull-requests/66/diff

When we started using topology_hiding we set it to use the public DNS address internally and externally and when we called the topology_hiding_match check_self was matched against the advertised address which was byoc.use1.genesys.cloud, this was the contact domain both internally and externally. Sequential requests from the dialog to the transaction server ignored the request domain in favour of using the dispatch module because we didn't need to tie sequential requests to a particular instance, if it crashes we are not guaranteed to get that IP address again and if the ASG scales down that instance is gone so sequentials would fail and the thinfo param contained all of the required routing information anyway so it could be processed on any instance.

In the above PR we changed it so that the contact domain was set to the DNS address with the trunk identifier on requests outbound from Genesys Cloud only and the internal contact domain was the private IP address of the instance, when sequentials would be sent to an instance it would fail if that request domain did not match the socket on the instance we are processing the request on, it hid for a while because the ASG size was small enough that the dispatcher table would get back to the correct instance eventually.

Now we decorate all of our sockets with a new param which defines a subnet mask to match on

`socket=10.27.150.250 subnet_mask 16` means any sequential from `10.27.0.0` will match when getting socket info and topology_hiding will work