### PR TITLE
maxfwds module incorrectly double decrementing if already parsed

### DIFF
--- a/modules/maxfwd/maxfwd.c
+++ b/modules/maxfwd/maxfwd.c
@@ -138,33 +138,33 @@ static int w_process_maxfwd_header(struct sip_msg* msg, int* mval)
 	int val;
 	str mf_value;
 
-	val=is_maxfwd_present(msg, &mf_value);
+	val = is_maxfwd_present(msg, &mf_value);
 	switch (val) {
 		/* header not found */
 		case -1:
-			if (add_maxfwd_header( msg, *mval)!=0)
-				goto error;
+			if (add_maxfwd_header(msg, *mval) !=0)
+				return -2;
 			return 2;
 		/* error */
 		case -2:
-			goto error;
-		/* found */
+			return -2;
+		/* found but zero */
 		case 0:
 			return -1;
+		/* found and greater than zero */
 		default:
-			if (val>max_limit){
+			if (val > max_limit) {
 				LM_DBG("value %d decreased to %d\n", val, max_limit);
-				val = max_limit+1;
+				val = max_limit + 1;
 			}
-			if ( decrement_maxfwd(msg, val, &mf_value)!=0 ) {
+
+			if (decrement_maxfwd(msg, val, &mf_value) != 0) {
 				LM_ERR("decrement failed!\n");
-				goto error;
+				return -2;
 			}
 	}
 
 	return 1;
-error:
-	return -2;
 }
 
 

--- a/modules/maxfwd/mf_funcs.c
+++ b/modules/maxfwd/mf_funcs.c
@@ -38,55 +38,60 @@
 #define MF_HDR "Max-Forwards: "
 #define MF_HDR_LEN (sizeof(MF_HDR) - 1)
 
-/* do a tricky thing and keep the parsed value of MAXFWD hdr incremented
- * by one in order to make difference between 0 (not set)
- * and 0 (zero value) - bogdan */
-#define IS_MAXWD_STORED(_msg_) \
+#define IS_MAXFWD_STORED(_msg_) \
 	((_msg_)->maxforwards->parsed)
-#define STORE_MAXWD_VAL(_msg_,_val_) \
-	(_msg_)->maxforwards->parsed = ((void*)(long)((_val_)+1))
-#define FETCH_MAXWD_VAL(_msg_) \
-	(((int)(long)(_msg_)->maxforwards->parsed)-1)
+#define STORE_MAXFWD_VAL(_msg_,_val_) \
+	(_msg_)->maxforwards->parsed = ((void*)(long)((_val_)))
+#define FETCH_MAXFWD_VAL(_msg_) \
+	(((int)(long)(_msg_)->maxforwards->parsed))
 
 /* looks for the MAX FORWARDS header
-   returns the its value, -1 if is not present or -2 for error */
-int is_maxfwd_present( struct sip_msg* msg , str *foo)
+   returns the its value, -1 if is not present or -2 for error or 0 for present */
+int is_maxfwd_present(struct sip_msg* msg, str *mf_value)
 {
-	int x, err;
+	int parsed_val, err;
 
 	/* lookup into the message for MAX FORWARDS header*/
-	if ( !msg->maxforwards ) {
-		if  ( parse_headers( msg , HDR_MAXFORWARDS_F, 0 )==-1 ){
-			LM_ERR("parsing MAX_FORWARD header failed!\n");
+	if (!msg->maxforwards) {
+		if (parse_headers(msg , HDR_MAXFORWARDS_F, 0) == -1){
+			LM_ERR("parsing Max-Forwards header failed!\n");
 			return -2;
 		}
+
 		if (!msg->maxforwards) {
-			LM_DBG("max_forwards header not found!\n");
+			LM_DBG("Max-Forwards header not found!\n");
 			return -1;
 		}
-	} else if (IS_MAXWD_STORED(msg)) {
-		trim_len( foo->len , foo->s , msg->maxforwards->body );
-		return FETCH_MAXWD_VAL(msg);
 	}
 
 	/* if header is present, trim to get only the string containing numbers */
-	trim_len( foo->len , foo->s , msg->maxforwards->body );
+	trim_len(mf_value->len , mf_value->s, msg->maxforwards->body);
+
+	/* even if the parsed is 0 because it's a null pointer or a zero value
+	 * it doesn't matter and we can assume it's not stored and just parse the body
+	 */
+	if (IS_MAXFWD_STORED(msg)) {
+		return FETCH_MAXFWD_VAL(msg);
+	}
 
 	/* convert from string to number */
-	x = str2s( foo->s,foo->len,&err);
-	if (err){
-		LM_ERR("unable to parse the max forwards number\n");
+	parsed_val = str2s(mf_value->s, mf_value->len, &err);
+	if (err) {
+		LM_ERR("unable to parse the Max-Forwards value\n");
+
 		return -2;
 	}
+
 	/* store the parsed values */
-	STORE_MAXWD_VAL(msg, x);
-	LM_DBG("value = %d \n",x);
-	return x;
+	STORE_MAXFWD_VAL(msg, parsed_val);
+	LM_DBG("value = %d \n", parsed_val);
+
+	return parsed_val;
 }
 
 
 
-int decrement_maxfwd( struct sip_msg* msg , int x, str *s)
+int decrement_maxfwd( struct sip_msg* msg, int x, str *s)
 {
 	int i;
 
@@ -94,7 +99,7 @@ int decrement_maxfwd( struct sip_msg* msg , int x, str *s)
 	x--;
 
 	/* update the stored value */
-	STORE_MAXWD_VAL(msg, x);
+	STORE_MAXFWD_VAL(msg, x);
 
 	/* rewriting the max-fwd value in the message (buf and orig) */
 	for(i = s->len - 1; i >= 0; i--) {


### PR DESCRIPTION
Fix for the issue @bcnewlin found where calling this script function https://opensips.org/docs/modules/3.4.x/sipmsgops.html#func_sipmsg_validate before calling this one https://opensips.org/docs/modules/3.4.x/maxfwd.html#func_mf_process_maxfwd_header resulted in a double decrement of the Max-Forwards header because the maxfwds module assumes lazy evaluation of the SIP headers but validating the whole message does an eager parse of the headers and the module thinks it has already been parsed by the maxfwds module which preincrements the header for validation purposes