### PR TITLE
TELECOM-10557: When creating a socket in OpenSIPs using a DNS address…

### DIFF
--- a/socket_info.c
+++ b/socket_info.c
@@ -487,6 +487,7 @@ int expand_interface(struct socket_info *si, struct socket_info** list)
 	sid.adv_port = si->adv_port;
 	sid.adv_name = si->adv_name_str.s; /* it is NULL terminated */
 	sid.tag = si->tag.s; /* it is NULL terminated */
+	sid.subnet_mask = si->subnet_mask;
 #ifdef HAVE_IFADDRS
 	/* use the getifaddrs interface to get all the interfaces */
 	struct ifaddrs *addrs;


### PR DESCRIPTION
When setting a socket with `eth0` or `localhost` or `my.domain.com` it tries to resolve the IP address before creating the socket, the `struct socket_id sid;` on line 481 when statically initialised does not zero out the subnet_mask when expanding the interfaces and causes what appears to be a random value to be set as the subnet, thanks @ghmj2417 for notifying me