### PR TITLE
TELECOM-10724: Fix for topology_hiding not preserving usernames on sequential requests

### DIFF
--- a/modules/topology_hiding/topo_hiding_logic.c
+++ b/modules/topology_hiding/topo_hiding_logic.c
@@ -2110,7 +2110,7 @@ static int topo_no_dlg_seq_handling(struct sip_msg *msg,str *info)
 		free_rr(&head);
 	pkg_free(dec_buf);
 
-	if (topo_no_dlg_encode_contact(msg,0,NULL) < 0) {
+	if (topo_no_dlg_encode_contact(msg,TOPOH_KEEP_USER,NULL) < 0) {
 		LM_ERR("Failed to encode contact header \n");
 		return -1;
 	}


### PR DESCRIPTION

**Summary**
Fix for topology_hiding not preserving usernames on sequential requests

**Details**
Because our transaction servers are not dialog aware when we use the topology_hiding_match function we were using the 'no dialog' code path which doesn't preserve the flag we initially set in the topology_hiding function. In our case this is the flag to preserve usernames in sequential requests. This simple fix just hardcodes the flag into the no dialog mode version (which should be 0 if the flag isn't set).
