### PR TITLE
TELECOM-10858: `dns_cache`: Add allowlist parameter to able to cache only specific domains

### DIFF
--- a/modules/dns_cache/dns_cache.c
+++ b/modules/dns_cache/dns_cache.c
@@ -53,10 +53,12 @@ static cachedb_con *cdbc = 0;
 
 static int blacklist_timeout=3600; /* seconds */
 static str cachedb_url = {0,0};
+static str allowlist = {0,0};
 
 static const param_export_t params[]={
 	{ "cachedb_url",                 STR_PARAM, &cachedb_url.s},
 	{ "blacklist_timeout",           INT_PARAM, &blacklist_timeout},
+	{ "allowlist",                   STR_PARAM, &allowlist.s},
 	{0,0,0}
 };
 
@@ -93,6 +95,44 @@ struct module_exports exports= {
 	child_init,			        /* per-child init function */
 	0                           /* reload confirm function */
 };
+
+#define DOMAIN_MAX_LENGTH 253
+#define ALLOWLIST_KEY_PREFIX "allowlist_"
+#define ALLOWLIST_MAX_KEY_LEN (DOMAIN_MAX_LENGTH + sizeof(ALLOWLIST_KEY_PREFIX) + 1)
+
+void create_allowlist_key(char* out_buf, str* out, const char* name) {
+	out->len = snprintf(out_buf, ALLOWLIST_MAX_KEY_LEN, "%s_%s", ALLOWLIST_KEY_PREFIX, name);
+	out->s = out_buf;
+}
+
+int init_allowlist(void) {
+	char *name;
+	str key, value;
+	char wkey[ALLOWLIST_MAX_KEY_LEN];
+
+	value.len = 0;
+	value.s = 0;
+
+	name = strtok(allowlist.s, ",");
+	while (name != NULL) {
+		create_allowlist_key(wkey, &key, name);
+		if (cdbf.set(cdbc, &key, &value, 0) < 0) return 0;
+		name = strtok(NULL, ",");
+	}
+
+	return 1;
+}
+
+int is_on_allowlist(const char* name) {
+	str key;
+	str res;
+	char wkey[ALLOWLIST_MAX_KEY_LEN];
+
+	create_allowlist_key(wkey, &key, name);
+
+	if (cdbf.get(cdbc, &key, &res) < 0) return 0;
+	return 1;
+}
 
 /**
  * init module function
@@ -133,6 +173,11 @@ static int child_init(int rank)
 	cdbc = cdbf.init(&cachedb_url);
 	if (!cdbc) {
 		LM_ERR("cannot connect to db_url %.*s\n", cachedb_url.len, cachedb_url.s);
+		return -1;
+	}
+
+	if (allowlist.s && !init_allowlist()) {
+		LM_ERR("Failed to initialize dns_cache allowlist: %.*s", allowlist.len, allowlist.s);
 		return -1;
 	}
 
@@ -833,6 +878,8 @@ int put_dnscache_value(char *name,int r_type,void *record,int rdata_len,
 		/* assume dns request before forking - cache is not ready yet */
 		return 1;
 	}
+
+	if (allowlist.s && !is_on_allowlist(name)) return 1;
 
 	/* avoid caching records with TTL=0 */
 	if (!failure && ttl==0) {


### PR DESCRIPTION
Usage to limit DNS cache for a specific addresses:
`modparam("dns_cache", "allowlist", "example.com,example2.com")`