### PR TITLE
TELECOM-11880: Working fix to revert to old behaviour

### DIFF
--- a/modules/rest_client/rest_methods.c
+++ b/modules/rest_client/rest_methods.c
@@ -415,9 +415,9 @@ static int init_transfer(CURL *handle, char *url, unsigned long timeout_s)
 	}
 
 	w_curl_easy_setopt(handle, CURLOPT_CONNECTTIMEOUT,
-			timeout_s && timeout_s < connection_timeout ? timeout_s : connection_timeout);
+			timeout_s && timeout_s > connection_timeout ? timeout_s : connection_timeout);
 	w_curl_easy_setopt(handle, CURLOPT_TIMEOUT,
-			timeout_s && timeout_s < curl_timeout ? timeout_s : curl_timeout);
+			timeout_s && timeout_s > curl_timeout ? timeout_s : curl_timeout);
 
 	w_curl_easy_setopt(handle, CURLOPT_VERBOSE, 1);
 	w_curl_easy_setopt(handle, CURLOPT_STDERR, stdout);
@@ -891,7 +891,7 @@ int start_async_http_req(struct sip_msg *msg, enum rest_client_method method,
 	multi_handle = multi_list->multi_handle;
 	curl_multi_add_handle(multi_handle, handle);
 
-	connect_timeout = (async_parm->timeout_s*1000) < connection_timeout_ms ?
+	connect_timeout = (async_parm->timeout_s*1000) > connection_timeout_ms ?
 			(async_parm->timeout_s*1000) : connection_timeout_ms;
 	timeout = connect_timeout;
 	busy_wait = connect_poll_interval;
@@ -974,7 +974,7 @@ int start_async_http_req(struct sip_msg *msg, enum rest_client_method method,
 			for (fd = 0; fd <= max_fd; fd++) {
 				if (FD_ISSET(fd, &rset)) {
 					LM_DBG("ongoing transfer on fd %d\n", fd);
-					if (connect > 0 && req_sz > 0 && is_new_transfer(fd)) {
+					if (req_sz > 0 && is_new_transfer(fd)) {
 						LM_DBG(">>> add fd %d to ongoing transfers\n", fd);
 						add_transfer(fd);
 						goto success;


### PR DESCRIPTION
So this is in addition to the rest client fixes, it is not a complete fix as of now but it will work with what we have currently given we only use the rest client to hit one endpoint, testing this locally with a very simple script which I can flood OPTIONs requests on a single process TCP worker and this is my observations

Current 3.4 build with no upstream patches or other changes, using the mockserver to respond, mockserver listens on port 1080 which is defined as the socks port using this command `ss -t -p -m -O | grep "127.0.0.1:socks users:((\"opensips\"" | wc -l` to count open sockets you'll see that with a max transfers of 200 it only opens 128 using this build it will open 200 using my basic script to do 2000 simultaneous OPTIONs requests, also casually observe timeouts on 3.4 whereas no timeouts occur here.

If you run the rest client as is in 3.6 or what is in upstream 3.4 you'll see max two sockets open and the pacing of the responses are observable to the naked eye where this basic script will take a much much longer time to finish so the current rest patches are a no go at the moment for our use case, we are relying on undefined behaviour which this will expose again but in a much more performant manner.

Next steps is that this patch is in a branch for 3.6 and it is going to soak in TCA today, then I will soak this change for v1 in TCA tomorrow and as a result of both of those behaving well I will open a ticket with OpenSIPs to let them know my findings and a potential solution to expose this behaviour in a modparam, thinking something like `max_concurrent_connections` or something in that ballpark and also a soak on double load day