### PR TITLE
TELECOM-11967: Make MI Datagram buffer size configurable

### DIFF
--- a/modules/mi_datagram/datagram_fnc.c
+++ b/modules/mi_datagram/datagram_fnc.c
@@ -192,7 +192,7 @@ err_rx:
 
 int mi_init_datagram_buffer(void){
 
-	mi_buf = pkg_malloc(DATAGRAM_SOCK_BUF_SIZE+1);
+	mi_buf = pkg_malloc(mi_sock_buf_size+1);
 	if ( mi_buf==NULL) {
 		LM_ERR("no more pkg memory\n");
 		return -1;
@@ -265,11 +265,11 @@ static int mi_send_dgram(int fd, char* buf, unsigned int len,
 	if(total_len == 0 || tolen ==0)
 		return -1;
 
-	if (total_len>DATAGRAM_SOCK_BUF_SIZE)
+	if (total_len>mi_sock_buf_size)
 	{
 		LM_DBG("datagram too big, "
-			"truncking, datagram_size is %i\n",DATAGRAM_SOCK_BUF_SIZE);
-		len = DATAGRAM_SOCK_BUF_SIZE;
+			"truncking, datagram_size is %i\n",mi_sock_buf_size);
+		len = mi_sock_buf_size;
 	}
 	/*LM_DBG("destination address length is %i\n", tolen);*/
 	n=sendto(fd, buf, len, 0, to, tolen);
@@ -300,12 +300,12 @@ static void datagram_close_async(mi_response_t *resp,struct mi_handler *hdl,
 	{
 		if (resp!=0) {
 			/*allocate the response datagram*/
-			print_buf.s = pkg_malloc(DATAGRAM_SOCK_BUF_SIZE);
+			print_buf.s = pkg_malloc(mi_sock_buf_size);
 			if(!print_buf.s){
 				LM_ERR("no more pkg memory\n");
 				return;
 			}
-			print_buf.len = DATAGRAM_SOCK_BUF_SIZE;
+			print_buf.len = mi_sock_buf_size;
 
 			ret = print_mi_response(resp, p->id,
 					&print_buf, mi_datagram_pp);
@@ -447,7 +447,7 @@ int mi_datagram_callback(int rx_sock, void *_tx_sock, int was_timeout)
 
 	reply_addr_len = sizeof(reply_addr);
 
-	ret = recvfrom(rx_sock, mi_buf, DATAGRAM_SOCK_BUF_SIZE, 0,
+	ret = recvfrom(rx_sock, mi_buf, mi_sock_buf_size, 0,
 				(struct sockaddr*)&reply_addr, &reply_addr_len);
 
 	if (ret < 0) {
@@ -469,7 +469,7 @@ int mi_datagram_callback(int rx_sock, void *_tx_sock, int was_timeout)
 	mi_buf[ret] = '\0';
 	LM_DBG("received %d |%.*s|\n", ret, ret, mi_buf);
 
-	if(ret> DATAGRAM_SOCK_BUF_SIZE){
+	if(ret> mi_sock_buf_size){
 		LM_ERR("buffer overflow, dropping\n");
 		return -1;
 	}
@@ -532,7 +532,7 @@ int mi_datagram_callback(int rx_sock, void *_tx_sock, int was_timeout)
 		trace_datagram_request(cmd, req_method, request.params);
 
 		print_buf.s = mi_buf;
-		print_buf.len = DATAGRAM_SOCK_BUF_SIZE;
+		print_buf.len = mi_sock_buf_size;
 		ret = print_mi_response(response, request.id,
 				&print_buf, mi_datagram_pp);
 

--- a/modules/mi_datagram/datagram_fnc.h
+++ b/modules/mi_datagram/datagram_fnc.h
@@ -39,7 +39,7 @@
 
 #include "mi_datagram.h"
 
-#define DATAGRAM_SOCK_BUF_SIZE 65457
+extern int mi_sock_buf_size;
 
 #define MI_PARSE_ERROR					 "400 Parse_error"
 #define MI_PARSE_ERROR_LEN               (sizeof(MI_PARSE_ERROR)-1)

--- a/modules/mi_datagram/doc/mi_datagram_admin.xml
+++ b/modules/mi_datagram/doc/mi_datagram_admin.xml
@@ -284,6 +284,26 @@ modparam("mi_fifo", "pretty_printing", 1)
 		</example>
 	</section>
 
+	<section id="param_socket_buf_size" xreflabel="socket_buf_size">
+		<title><varname>socket_buf_size</varname> (integer)</title>
+		<para>
+		Maximum buffer size used when receiving and sending.
+		</para>
+		<para>
+		<emphasis>
+			Default value is 65457.
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <varname>socket_buf_size</varname> parameter</title>
+		<programlisting format="linespecific">
+		...
+		modparam("mi_datagram", "socket_buf_size", 131072)
+		...
+		</programlisting>
+		</example>
+	</section>
+
 
 
 	</section>

--- a/modules/mi_datagram/mi_datagram.c
+++ b/modules/mi_datagram/mi_datagram.c
@@ -72,6 +72,8 @@ sockaddr_dtgram mi_dtgram_addr;
 /* socket definition parameter */
 static char *mi_socket = 0;
 int mi_socket_timeout = 2000;
+const int mi_sock_buf_size_default = 65457;
+int mi_sock_buf_size = mi_sock_buf_size_default;
 static rx_tx_sockets sockets;
 
 /* unixsock specific parameters */
@@ -103,6 +105,7 @@ static const param_export_t mi_params[] = {
 	{"children_count",      INT_PARAM,    &mi_procs[0].no           },
 	{"socket_name",         STR_PARAM,    &mi_socket                },
 	{"socket_timeout",      INT_PARAM,    &mi_socket_timeout        },
+	{"socket_buf_size",     INT_PARAM,    &mi_sock_buf_size         },
 	{"unix_socket_mode",    INT_PARAM,    &mi_unix_socket_mode      },
 	{"unix_socket_group",   STR_PARAM,    &mi_unix_socket_gid_s     },
 	{"unix_socket_group",   INT_PARAM,    &mi_unix_socket_gid       },
@@ -147,6 +150,12 @@ static int mi_mod_init(void)
 	struct hostent * host;
 	char *p, *host_s;
 	str port_str;
+
+	if (mi_sock_buf_size <= 0) {
+		LM_WARN("invalid 'socket_buf_size' (%d), resetting to default %d\n",
+				mi_sock_buf_size, mi_sock_buf_size_default);
+		mi_sock_buf_size = mi_sock_buf_size_default;
+	}
 
 	/* checking the mi_socket module param */
 	LM_DBG("testing socket existence...\n");


### PR DESCRIPTION
Please comment on https://github.com/purecloudlabs/opensips/pull/111, this is a port to `3.6`.