### PR TITLE
Gcvcallp 3053

### DIFF
--- a/blacklists.c
+++ b/blacklists.c
@@ -40,6 +40,7 @@
 #include "context.h"
 #include "timer.h"
 #include "ut.h"
+#include "redact_pii.h"
 
 static struct bl_head *blst_heads;
 static unsigned int bl_default_marker;
@@ -1060,7 +1061,7 @@ static mi_response_t *mi_check_all_blacklists(const mi_params_t *params,
 		if (add_mi_string(resp_arr, NULL, 0, blst_heads[i].name.s,
 				blst_heads[i].name.len) < 0) {
 			LM_ERR("cannot add blacklist %.*s\n",
-					blst_heads[i].name.len, blst_heads[i].name.s);
+					blst_heads[i].name.len, redact_pii(blst_heads[i].name.s));
 			free_mi_response(resp);
 			resp = NULL;
 			goto end;

--- a/cfg.lex
+++ b/cfg.lex
@@ -279,6 +279,7 @@ MCAST_LOOPBACK		"mcast_loopback"
 MCAST_TTL			"mcast_ttl"
 TOS					"tos"
 DISABLE_DNS_FAILOVER  "disable_dns_failover"
+REDACT_PII_ "redact_pii_"
 DISABLE_DNS_BLACKLIST "disable_dns_blacklist"
 DST_BLACKLIST		"dst_blacklist"
 MAX_WHILE_LOOPS "max_while_loops"
@@ -524,6 +525,8 @@ SPACE		[ ]
 									return TOS; }
 <INITIAL>{DISABLE_DNS_FAILOVER}	{	count(); yylval.strval=yytext;
 									return DISABLE_DNS_FAILOVER; }
+<INITIAL>{REDACT_PII_}	{	count(); yylval.strval=yytext; 
+									return REDACT_PII_;}
 <INITIAL>{DISABLE_DNS_BLACKLIST}	{	count(); yylval.strval=yytext;
 									return DISABLE_DNS_BLACKLIST; }
 <INITIAL>{DST_BLACKLIST}	{	count(); yylval.strval=yytext;

--- a/cfg.lex
+++ b/cfg.lex
@@ -280,6 +280,8 @@ MCAST_TTL			"mcast_ttl"
 TOS					"tos"
 DISABLE_DNS_FAILOVER  "disable_dns_failover"
 REDACT_PII_ "redact_pii_"
+REDACT_TEMPLATE "redact_template"
+REDACT_MODE "redact_mode"
 DISABLE_DNS_BLACKLIST "disable_dns_blacklist"
 DST_BLACKLIST		"dst_blacklist"
 MAX_WHILE_LOOPS "max_while_loops"
@@ -527,6 +529,10 @@ SPACE		[ ]
 									return DISABLE_DNS_FAILOVER; }
 <INITIAL>{REDACT_PII_}	{	count(); yylval.strval=yytext; 
 									return REDACT_PII_;}
+<INITIAL>{REDACT_TEMPLATE}	{	count(); yylval.strval=yytext;
+									return REDACT_TEMPLATE;}
+<INITIAL>{REDACT_MODE}	{	count(); yylval.strval=yytext;
+									return REDACT_MODE;}
 <INITIAL>{DISABLE_DNS_BLACKLIST}	{	count(); yylval.strval=yytext;
 									return DISABLE_DNS_BLACKLIST; }
 <INITIAL>{DST_BLACKLIST}	{	count(); yylval.strval=yytext;

--- a/cfg.y
+++ b/cfg.y
@@ -1598,6 +1598,20 @@ assign_stm: LOGLEVEL EQUAL snumber { IFOR();
 		| REDACT_PII_ error { yyerror("boolean value expected"); }
 		| REDACT_TEMPLATE EQUAL STRING { IFOR();
 										redact_template=$3;
+										if (redact_mode == REDACT_FORMAT) {
+											char *pct = strstr(redact_template, "%s");
+											if (pct) {
+												redact_fmt.left.s = redact_template;
+												redact_fmt.left.len = pct - redact_template;
+												redact_fmt.right.s = pct + 2;
+												redact_fmt.right.len = strlen(pct + 2);
+											} else {
+												redact_fmt.left.s = redact_template;
+												redact_fmt.left.len = strlen(redact_template);
+												redact_fmt.right.s = "";
+												redact_fmt.right.len = 0;
+											}
+										}
 									}
 		| REDACT_TEMPLATE error { yyerror("string value expected"); }
 		| REDACT_MODE EQUAL STRING { IFOR();
@@ -1607,8 +1621,23 @@ assign_stm: LOGLEVEL EQUAL snumber { IFOR();
 											redact_mode=REDACT_APPEND;
 										else if (strcasecmp($3, "prepend")==0)
 											redact_mode=REDACT_PREPEND;
-										else if (strcasecmp($3, "format")==0)
+										else if (strcasecmp($3, "format")==0) {
 											redact_mode=REDACT_FORMAT;
+											if (redact_template) {
+												char *pct = strstr(redact_template, "%s");
+												if (pct) {
+													redact_fmt.left.s = redact_template;
+													redact_fmt.left.len = pct - redact_template;
+													redact_fmt.right.s = pct + 2;
+													redact_fmt.right.len = strlen(pct + 2);
+												} else {
+													redact_fmt.left.s = redact_template;
+													redact_fmt.left.len = strlen(redact_template);
+													redact_fmt.right.s = "";
+													redact_fmt.right.len = 0;
+												}
+											}
+										}
 										else
 											yyerror("redact_mode must be: replace|append|prepend|format");
 									}

--- a/cfg.y
+++ b/cfg.y
@@ -393,6 +393,7 @@ extern int cfg_parse_only_routes;
 %token MCAST_TTL
 %token TOS
 %token DISABLE_DNS_FAILOVER
+%token REDACT_PII_
 %token DISABLE_DNS_BLACKLIST
 %token DST_BLACKLIST
 %token DISABLE_STATELESS_FWD
@@ -1588,6 +1589,10 @@ assign_stm: LOGLEVEL EQUAL snumber { IFOR();
 										disable_dns_failover=$3;
 									}
 		| DISABLE_DNS_FAILOVER error { yyerror("boolean value expected"); }
+		| REDACT_PII_ EQUAL NUMBER { IFOR();
+										redact_pii_=$3;
+									}
+		| REDACT_PII_ error { yyerror("boolean value expected"); }				
 		| DISABLE_DNS_BLACKLIST EQUAL NUMBER { IFOR();
 										disable_dns_blacklist=$3;
 									}

--- a/cfg.y
+++ b/cfg.y
@@ -111,6 +111,7 @@
 #include "config.h"
 #include "mem/rpm_mem.h"
 #include "poll_types.h"
+#include "redact_pii.h"
 
 #ifdef SHM_EXTRA_STATS
 #include "mem/module_info.h"
@@ -394,6 +395,8 @@ extern int cfg_parse_only_routes;
 %token TOS
 %token DISABLE_DNS_FAILOVER
 %token REDACT_PII_
+%token REDACT_TEMPLATE
+%token REDACT_MODE
 %token DISABLE_DNS_BLACKLIST
 %token DST_BLACKLIST
 %token DISABLE_STATELESS_FWD
@@ -1592,7 +1595,24 @@ assign_stm: LOGLEVEL EQUAL snumber { IFOR();
 		| REDACT_PII_ EQUAL NUMBER { IFOR();
 										redact_pii_=$3;
 									}
-		| REDACT_PII_ error { yyerror("boolean value expected"); }				
+		| REDACT_PII_ error { yyerror("boolean value expected"); }
+		| REDACT_TEMPLATE EQUAL STRING { IFOR();
+										redact_template=$3;
+									}
+		| REDACT_TEMPLATE error { yyerror("string value expected"); }
+		| REDACT_MODE EQUAL STRING { IFOR();
+										if (strcasecmp($3, "replace")==0)
+											redact_mode=REDACT_REPLACE;
+										else if (strcasecmp($3, "append")==0)
+											redact_mode=REDACT_APPEND;
+										else if (strcasecmp($3, "prepend")==0)
+											redact_mode=REDACT_PREPEND;
+										else if (strcasecmp($3, "format")==0)
+											redact_mode=REDACT_FORMAT;
+										else
+											yyerror("redact_mode must be: replace|append|prepend|format");
+									}
+		| REDACT_MODE error { yyerror("string value expected (replace|append|prepend|format)"); }
 		| DISABLE_DNS_BLACKLIST EQUAL NUMBER { IFOR();
 										disable_dns_blacklist=$3;
 									}

--- a/core_cmds.c
+++ b/core_cmds.c
@@ -44,6 +44,8 @@
 #include "mod_fix.h"
 /* needed by tcpconn_add_alias() */
 #include "net/tcp_conn_defs.h"
+#include "net/net_tcp.h"
+#include "redact_pii.h"
 
 static int fixup_forward_dest(void** param);
 static int fixup_destination(void** param);
@@ -552,7 +554,7 @@ static int fixup_f_send_sock(void** param)
 
 	he=resolvehost(host_nt.s,0);
 	if (he==0){
-		LM_ERR(" could not resolve %s\n", host_nt.s);
+		LM_ERR(" could not resolve %s\n", redact_pii(host_nt.s));
 		goto error;
 	}
 	hostent2ip_addr(&ip, he, 0);

--- a/dset.c
+++ b/dset.c
@@ -37,6 +37,7 @@
 #include "mem/mem.h"
 #include "ip_addr.h"
 #include "usr_avp.h"
+#include "redact_pii.h"
 
 #define CONTACT "Contact: "
 #define CONTACT_LEN (sizeof(CONTACT) - 1)
@@ -321,7 +322,7 @@ int update_msg_branch_uri(unsigned int idx, str *val)
 	br = dsct->branches + idx;
 
 	if (val->len > MAX_URI_SIZE - 1) {
-		LM_ERR("too long uri: [%.*s]/%d\n", val->len, val->s, val->len);
+		LM_ERR("too long uri: [%.*s]/%d\n", val->len, redact_pii(val->s), val->len);
 		return -1;
 	}
 	br->branch.uri.s = br->uri; /* internal buffer */
@@ -350,7 +351,7 @@ int update_msg_branch_dst_uri(unsigned int idx, str *val)
 		br->branch.dst_uri.len = 0;
 	} else {
 		if (val->len > MAX_URI_SIZE - 1) {
-			LM_ERR("too long dst_uri: [%.*s]/%d\n", val->len, val->s,val->len);
+			LM_ERR("too long dst_uri: [%.*s]/%d\n", val->len, redact_pii(val->s),val->len);
 			return -1;
 		}
 		br->branch.dst_uri.s = br->dst_uri; /* internal buffer */

--- a/forward.c
+++ b/forward.c
@@ -79,6 +79,7 @@
 #include "blacklists.h"
 #include "msg_callbacks.h"
 #include "md5utils.h"
+#include "redact_pii.h"
 
 
 
@@ -512,7 +513,7 @@ int forward_reply(struct sip_msg* msg)
 					msg->via1->port?msg->via1->port:SIP_PORT,
 					msg->via1->proto)!=1){
 			LM_ERR("host in first via!=me : %.*s:%d\n",
-				msg->via1->host.len, msg->via1->host.s,	msg->via1->port);
+				msg->via1->host.len, redact_pii(msg->via1->host.s), msg->via1->port);
 			/* send error msg back? */
 			goto error;
 		}

--- a/globals.h
+++ b/globals.h
@@ -102,6 +102,7 @@ extern int mcast_ttl;
 extern int tos;
 
 extern int disable_dns_failover;
+extern int redact_pii_;
 extern int disable_dns_blacklist;
 
 extern int cfg_errors;

--- a/lib/reg/path.c
+++ b/lib/reg/path.c
@@ -26,6 +26,7 @@
 #include "../../parser/parse_uri.h"
 #include "../../ut.h"
 #include "../../strcommon.h"
+#include "../../redact_pii.h"
 
 #include "path.h"
 #include "config.h"
@@ -122,7 +123,7 @@ int build_path_vector(struct sip_msg *_m, str *path, str *received,
 				                           &unescape_buf) != 0)
 					LM_ERR("failed to unescape received=%.*s\n",
 					       hooks.contact.received->body.len,
-					       hooks.contact.received->body.s);
+					       redact_pii(hooks.contact.received->body.s));
 				else
 					*received = unescape_buf;
 			}

--- a/lib/reg/pn.c
+++ b/lib/reg/pn.c
@@ -28,6 +28,7 @@
 #include "../../usr_avp.h"
 #include "../../data_lump.h"
 #include "../../data_lump_rpl.h"
+#include "../../redact_pii.h"
 
 #include "../../modules/usrloc/ul_evi.h"
 #include "../../modules/event_routing/api.h"
@@ -280,7 +281,7 @@ enum pn_action pn_inspect_ct_params(struct sip_msg *req, const str *ct_uri)
 	int i, is_cap_query = 1, is_handled_upstream = 0;
 
 	if (parse_uri(ct_uri->s, ct_uri->len, &puri) != 0) {
-		LM_ERR("failed to parse Contact URI '%.*s'\n", ct_uri->len, ct_uri->s);
+		LM_ERR("failed to parse Contact URI '%.*s'\n", ct_uri->len, redact_pii(ct_uri->s));
 		return -1;
 	}
 
@@ -551,7 +552,7 @@ static struct usr_avp *pn_trim_pn_params(evi_params_t *params)
               pn_has_uri_params(&p->val.s, &puri)) {
 			if (pn_remove_uri_params(&puri, p->val.s.len, &_sval) != 0) {
 				LM_ERR("failed to remove PN params from Contact '%.*s'\n",
-				       p->val.s.len, p->val.s.s);
+				       p->val.s.len, redact_pii(p->val.s.s));
 				sval = &p->val.s;
 			} else {
 				sval = &_sval;
@@ -641,13 +642,13 @@ int pn_awake_pn_contacts(struct sip_msg *req, ucontact_t **cts, int sz,
 	for (end = cts + sz; cts < end; cts++) {
 		if (parse_uri((*cts)->c.s, (*cts)->c.len, &puri) != 0) {
 			LM_ERR("failed to parse Contact '%.*s'\n",
-			       (*cts)->c.len, (*cts)->c.s);
+			       (*cts)->c.len, redact_pii((*cts)->c.s));
 			continue;
 		}
 
 		if (pn_trigger_pn(req, *cts, &puri) != 0) {
 			LM_ERR("failed to trigger PN for Contact: '%.*s'\n",
-			       (*cts)->c.len, (*cts)->c.s);
+			       (*cts)->c.len, redact_pii((*cts)->c.s));
 			continue;
 		}
 
@@ -670,7 +671,7 @@ int pn_trigger_pn(struct sip_msg *req, const ucontact_t *ct,
 		if (get_uri_param_val(ct_uri, &f->uri_param_key, &f->val) != 0) {
 			LM_ERR("failed to locate '%.*s' URI param in Contact '%.*s'\n",
 			       f->uri_param_key.len, f->uri_param_key.s,
-			       ct->c.len, ct->c.s);
+			       ct->c.len, redact_pii(ct->c.s));
 			return -1;
 		}
 	}
@@ -679,7 +680,7 @@ int pn_trigger_pn(struct sip_msg *req, const ucontact_t *ct,
 	        pn_trim_pn_params, pn_notify_branch, pn_refresh_timeout,
 	        EBR_SUBS_EXPIRE_NOTIFY) != 0) {
 		LM_ERR("failed to EBR-subscribe to "UL_EV_CT_UPDATE", Contact: %.*s\n",
-		       ct->c.len, ct->c.s);
+		       ct->c.len, redact_pii(ct->c.s));
 		return -1;
 	}
 
@@ -704,7 +705,7 @@ int pn_has_uri_params(const str *ct, struct sip_uri *puri)
 		puri = &_puri;
 
 	if (parse_uri(ct->s, ct->len, puri) != 0) {
-		LM_ERR("failed to parse contact: '%.*s'\n", ct->len, ct->s);
+		LM_ERR("failed to parse contact: '%.*s'\n", ct->len, redact_pii(ct->s));
 		return 0;
 	}
 
@@ -802,7 +803,7 @@ int pn_async_process_purr(struct sip_msg *req, async_ctx *ctx, udomain_t *d)
 	/* locate "pn-purr" in the R-URI */
 	if (parse_sip_msg_uri(req) < 0) {
 		LM_ERR("failed to parse R-URI: '%.*s'\n",
-		       GET_RURI(req)->len, GET_RURI(req)->s);
+		       GET_RURI(req)->len, redact_pii(GET_RURI(req)->s));
 		return -1;
 	}
 
@@ -825,7 +826,7 @@ int pn_async_process_purr(struct sip_msg *req, async_ctx *ctx, udomain_t *d)
 
 	rt_uri = &((rr_t *)req->route->parsed)->nameaddr.uri;
 	if (parse_uri(rt_uri->s, rt_uri->len, &puri) != 0) {
-		LM_ERR("failed to parse Route URI: '%.*s'\n", rt_uri->len, rt_uri->s);
+		LM_ERR("failed to parse Route URI: '%.*s'\n", rt_uri->len, redact_pii(rt_uri->s));
 		return -1;
 	}
 
@@ -854,7 +855,7 @@ have_purr:
 	       purr->len, purr->s);
 
 	if (parse_uri(c->c.s, c->c.len, &puri) != 0) {
-		LM_ERR("failed to parse Contact: '%.*s'\n", c->c.len, c->c.s);
+		LM_ERR("failed to parse Contact: '%.*s'\n", c->c.len, redact_pii(c->c.s));
 		goto err_unlock;
 	}
 
@@ -863,7 +864,7 @@ have_purr:
 		if (get_uri_param_val(&puri, &f->uri_param_key, &f->val) != 0) {
 			LM_ERR("failed to locate '%.*s' URI param in Contact '%.*s'\n",
 			       f->uri_param_key.len, f->uri_param_key.s,
-			       c->c.len, c->c.s);
+			       c->c.len, redact_pii(c->c.s));
 			goto err_unlock;
 		}
 	}
@@ -872,7 +873,7 @@ have_purr:
 	if (ebr.async_wait_for_event(req, ctx, ev_ct_update, pn_ebr_filters,
 	          pn_trim_pn_params, pn_refresh_timeout) != 0) {
 		LM_ERR("failed to EBR-subscribe to "UL_EV_CT_UPDATE", ct: '%.*s'\n",
-		       c->c.len, c->c.s);
+		       c->c.len, redact_pii(c->c.s));
 		goto err_unlock;
 	}
 
@@ -903,7 +904,7 @@ int pn_add_reply_purr(const ucontact_t *ct)
 		return 0;
 
 	if (parse_uri(ct->c.s, ct->c.len, &puri) != 0) {
-		LM_ERR("failed to parse Contact URI: '%.*s'\n", ct->c.len, ct->c.s);
+		LM_ERR("failed to parse Contact URI: '%.*s'\n", ct->c.len, redact_pii(ct->c.s));
 		return -1;
 	}
 

--- a/lib/reg/sip_msg.c
+++ b/lib/reg/sip_msg.c
@@ -23,6 +23,7 @@
 
 #include "../../parser/contact/parse_contact.h"
 #include "../../parser/parse_uri.h"
+#include "../../redact_pii.h"
 
 #include "common.h"
 
@@ -420,7 +421,7 @@ int calc_contact_q(param_t* _q, qvalue_t* _r)
 		if (rc < 0) {
 			rerrno = R_INV_Q; /* Invalid q parameter */
 			LM_ERR("invalid qvalue (%.*s): %s\n",
-					_q->body.len, _q->body.s, qverr2str(rc));
+					_q->body.len, redact_pii(_q->body.s), qverr2str(rc));
 			return -1;
 		}
 	}

--- a/modules/auth_db/checks.c
+++ b/modules/auth_db/checks.c
@@ -41,6 +41,7 @@
 #include "../../pvar.h"
 #include "../../script_var.h"
 #include "../../mod_fix.h"
+#include "../../redact_pii.h"
 #include "authdb_mod.h"
 #include "checks.h"
 
@@ -296,7 +297,7 @@ int get_auth_id(struct sip_msg* _msg, str *_table, str* uri,
 	if (parse_uri(uri->s, uri->len, &sip_uri) < 0
 	&& (sip_uri.user.s == NULL || sip_uri.user.len <= 0)) {
 		LM_ERR("First parameter must be a URI with username (val = '%.*s').",
-			uri->len, uri->s);
+			uri->len, redact_pii(uri->s));
 		return -1;
 	}
 

--- a/modules/b2b_entities/dlg.c
+++ b/modules/b2b_entities/dlg.c
@@ -44,6 +44,7 @@
 #include "../../action.h"
 #include "../../trim.h"
 #include "../../profiling.h"
+#include "../../redact_pii.h"
 #include "dlg.h"
 #include "b2b_entities.h"
 #include "b2be_db.h"
@@ -901,7 +902,7 @@ int b2b_prescript_f(struct sip_msg *msg, void *uparam)
 		/* check if first route is local*/
 		if ( parse_uri(rt->nameaddr.uri.s,rt->nameaddr.uri.len,&puri)!=0 ) {
 			LM_ERR("Route uri is not valid <%.*s>\n",
-				rt->nameaddr.uri.len,rt->nameaddr.uri.s);
+				rt->nameaddr.uri.len,redact_pii(rt->nameaddr.uri.s));
 			goto scb_run_all;
 		}
 		if (check_self_strict( &puri.host, puri.port_no, puri.proto)!= 1 ) {
@@ -924,7 +925,7 @@ int b2b_prescript_f(struct sip_msg *msg, void *uparam)
 		if (rt) {
 			if ( parse_uri(rt->nameaddr.uri.s,rt->nameaddr.uri.len,&puri)!=0 ){
 				LM_ERR("Second route uri is not valid <%.*s>\n",
-					rt->nameaddr.uri.len,rt->nameaddr.uri.s);
+					rt->nameaddr.uri.len,redact_pii(rt->nameaddr.uri.s));
 				goto scb_run_all;
 			}
 			if (check_self_strict( &puri.host, puri.port_no, puri.proto)!= 1 ){

--- a/modules/b2b_logic/logic.c
+++ b/modules/b2b_logic/logic.c
@@ -50,6 +50,7 @@
 #include "../presence/hash.h"
 #include "../presence/utils_func.h"
 #include "../../lib/csv.h"
+#include "../../redact_pii.h"
 
 #include "records.h"
 #include "b2b_logic.h"
@@ -507,7 +508,7 @@ int b2b_get_local_contact(struct sip_msg *msg, str *from_uri, str *local_contact
 		if (msg) {
 			memset(&ct_uri, 0, sizeof(struct sip_uri));
 			if (contact_user && parse_uri(from_uri->s, from_uri->len, &ct_uri) < 0) {
-				LM_ERR("Not a valid sip uri [%.*s]\n", from_uri->len, from_uri->s);
+				LM_ERR("Not a valid sip uri [%.*s]\n", from_uri->len, redact_pii(from_uri->s));
 				return -1;
 			}
 
@@ -753,7 +754,7 @@ int retry_init_bridge(struct sip_msg *msg, b2bl_tuple_t* tuple,
 			memset(&ct_uri, 0, sizeof(struct sip_uri));
 			if (contact_user && parse_uri(ci.from_uri.s, ci.from_uri.len, &ct_uri) < 0)
 			{
-				LM_ERR("Not a valid sip uri [%.*s]\n", ci.from_uri.len, ci.from_uri.s);
+				LM_ERR("Not a valid sip uri [%.*s]\n", ci.from_uri.len, redact_pii(ci.from_uri.s));
 				goto error;
 			}
 			get_local_contact(ci.send_sock, &ct_uri.user, &ci.local_contact);
@@ -2830,7 +2831,7 @@ str* create_top_hiding_entities(struct sip_msg* msg, b2bl_cback_f cbf,
 
 	memset(&ct_uri, 0, sizeof(struct sip_uri));
 	if (contact_user && parse_uri(ci.from_uri.s, ci.from_uri.len, &ct_uri) < 0) {
-		LM_ERR("Not a valid sip uri [%.*s]\n", ci.from_uri.len, ci.from_uri.s);
+		LM_ERR("Not a valid sip uri [%.*s]\n", ci.from_uri.len, redact_pii(ci.from_uri.s));
 		goto error;
 	}
 	get_local_contact((ci.send_sock?ci.send_sock:ci.pref_sock), &ct_uri.user, &ci.local_contact);
@@ -3014,7 +3015,7 @@ str *b2b_scenario_hdrs(struct b2bl_new_entity *entity)
 			if (!tmp_buf) {
 				LM_ERR("not enough memory to add header <%.*s: %.*s>\n",
 					name_value.s.len, name_value.s.s,
-					body_value.s.len, body_value.s.s);
+					body_value.s.len, redact_pii(body_value.s.s));
 				continue;
 			}
 			b2b_hdrs_buf.s = tmp_buf;
@@ -3579,7 +3580,7 @@ static struct b2bl_new_entity *tmp_client_new(struct sip_msg *msg, str *id,
 		if (parse_uri(entity->dest_uri.s, entity->dest_uri.len,
 			&sip_uri) < 0) {
 			LM_ERR("Not a valid sip uri [%.*s]\n",
-				entity->dest_uri.len, entity->dest_uri.s);
+				entity->dest_uri.len, redact_pii(entity->dest_uri.s));
 			goto error;
 		}
 	}
@@ -3597,7 +3598,7 @@ static struct b2bl_new_entity *tmp_client_new(struct sip_msg *msg, str *id,
 		if (parse_uri(entity->proxy.s, entity->proxy.len,
 			&sip_uri) < 0) {
 			LM_ERR("Not a valid sip uri [%.*s]\n",
-				entity->proxy.len, entity->proxy.s);
+				entity->proxy.len, redact_pii(entity->proxy.s));
 			goto error;
 		}
 	}
@@ -3946,7 +3947,7 @@ int b2bl_entity_new(struct sip_msg *msg, str *id, str *dest_uri, str *proxy,
 		if (parse_uri(entity->dest_uri.s, entity->dest_uri.len,
 			&sip_uri) < 0) {
 			LM_ERR("Not a valid sip uri [%.*s]\n",
-				entity->dest_uri.len, entity->dest_uri.s);
+				entity->dest_uri.len, redact_pii(entity->dest_uri.s));
 			goto error;
 		}
 	}
@@ -3965,7 +3966,7 @@ int b2bl_entity_new(struct sip_msg *msg, str *id, str *dest_uri, str *proxy,
 		if (parse_uri(entity->proxy.s, entity->proxy.len,
 			&sip_uri) < 0) {
 			LM_ERR("Not a valid sip uri [%.*s]\n",
-				entity->proxy.len, entity->proxy.s);
+				entity->proxy.len, redact_pii(entity->proxy.s));
 			goto error;
 		}
 	}

--- a/modules/cpl_c/cpl_parser.c
+++ b/modules/cpl_c/cpl_parser.c
@@ -33,6 +33,7 @@
 #include "../../dprint.h"
 #include "../../str.h"
 #include "../../ut.h"
+#include "../../redact_pii.h"
 #include "CPL_tree.h"
 #include "sub_list.h"
 #include "cpl_log.h"
@@ -848,7 +849,7 @@ static inline int encode_location_attr(xmlNodePtr  node, char *node_ptr,
 				/* check if it's a valid SIP URL -> just call
 				 * parse uri function and see if returns error ;-) */
 				if (parse_uri( val.s, val.len, &uri)!=0) {
-					LM_ERR("<%s> is not a valid SIP URL\n",val.s);
+					LM_ERR("<%s> is not a valid SIP URL\n",redact_pii(val.s));
 					goto error;
 				}
 				val.len++; /*copy also the \0 */
@@ -913,7 +914,7 @@ static inline int encode_rmvloc_attr(xmlNodePtr  node, char *node_ptr, char *buf
 				/* check if it's a valid SIP URL -> just call
 				 * parse uri function and see if returns error ;-) */
 				if (parse_uri( val.s, val.len, &uri)!=0) {
-					LM_ERR("<%s> is not a valid SIP URL\n",val.s);
+					LM_ERR("<%s> is not a valid SIP URL\n",redact_pii(val.s));
 					goto error;
 				}
 				val.len++; /*copy also the \0 */

--- a/modules/cpl_c/cpl_proxy.h
+++ b/modules/cpl_c/cpl_proxy.h
@@ -25,6 +25,7 @@
  */
 
 #include "../tm/h_table.h"
+#include "../../redact_pii.h"
 #include "../../parser/contact/parse_contact.h"
 
 
@@ -126,7 +127,7 @@ static inline int add_contacts_to_loc_set(struct sip_msg* msg,
 			/* add the uri to location set */
 			if (add_location(loc_set,&contacts->uri,0,prio,CPL_LOC_DUPL)!=0) {
 				LM_ERR("unable to add <%.*s>\n",
-					contacts->uri.len,contacts->uri.s);
+					contacts->uri.len,redact_pii(contacts->uri.s));
 			}
 		}
 	}

--- a/modules/cpl_c/cpl_sig.c
+++ b/modules/cpl_c/cpl_sig.c
@@ -21,6 +21,7 @@
 
 #include "../../action.h"
 #include "../../dset.h"
+#include "../../redact_pii.h"
 #include "../tm/tm_load.h"
 #include "loc_set.h"
 #include "cpl_sig.h"
@@ -82,7 +83,7 @@ int cpl_proxy_to_loc_set( struct sip_msg *msg, struct location **locs,
 		branch.q = Q_UNSPECIFIED;
 		branch.bflags = bflags;
 		if (append_msg_branch(&branch)==-1){
-			LM_ERR("failed when appending branch <%s>\n",(*locs)->addr.uri.s);
+			LM_ERR("failed when appending branch <%s>\n",redact_pii((*locs)->addr.uri.s));
 			goto error;
 		}
 		/* free the location and point to the next one */

--- a/modules/dialog/dlg_handlers.c
+++ b/modules/dialog/dlg_handlers.c
@@ -36,6 +36,7 @@
 #include "../../parser/parse_hname2.h"
 #include "../../parser/parser_f.h"
 #include "../../msg_callbacks.h"
+#include "../../redact_pii.h"
 #include "../tm/tm_load.h"
 #include "../rr/api.h"
 #include "dlg_hash.h"
@@ -566,7 +567,7 @@ static inline str* extract_mangled_touri(str *mangled_to_hdr)
 
 	parse_to(tmp,end,&to_b);
 	if (to_b.error == PARSE_ERROR) {
-		LM_ERR("bad to header [%.*s]\n",mangled_to_hdr->len,mangled_to_hdr->s);
+		LM_ERR("bad to header [%.*s]\n",mangled_to_hdr->len,redact_pii(mangled_to_hdr->s));
 		return NULL;
 	}
 
@@ -603,7 +604,7 @@ static inline str* extract_mangled_fromuri(str *mangled_from_hdr)
 
 	parse_to(tmp,end,&from_b);
 	if (from_b.error == PARSE_ERROR) {
-		LM_ERR("bad from header [%.*s]\n",mangled_from_hdr->len,mangled_from_hdr->s);
+		LM_ERR("bad from header [%.*s]\n",mangled_from_hdr->len,redact_pii(mangled_from_hdr->s));
 		return NULL;
 	}
 
@@ -795,10 +796,10 @@ static void dlg_onreply(struct cell* t, int type, struct tmcb_params *param)
 					mangled_to.s = NULL;
 				} else {
 					if ((req->msg_flags & FL_USE_UAC_FROM) && (mangled_from.len == 0 || mangled_from.s == NULL))
-						LM_CRIT("extract_ftc_hdrs ok but no from extracted : [%.*s]\n",req_out_buff->len,req_out_buff->s);
+						LM_CRIT("extract_ftc_hdrs ok but no from extracted : [%.*s]\n",req_out_buff->len,redact_pii(req_out_buff->s));
 
 					if ((req->msg_flags & FL_USE_UAC_TO) && (mangled_to.len == 0 || mangled_to.s == NULL))
-						LM_CRIT("extract_ftc_hdrs ok but no to extracted : [%.*s]\n",req_out_buff->len,req_out_buff->s);
+						LM_CRIT("extract_ftc_hdrs ok but no to extracted : [%.*s]\n",req_out_buff->len,redact_pii(req_out_buff->s));
 				}
 			}
 			push_reply_in_dialog( req, rpl, t, dlg,&mangled_from,&mangled_to, &leg_idx);
@@ -1633,7 +1634,7 @@ static inline int dlg_update_contact(struct dlg_cell *dlg, struct sip_msg *msg,
 		trim_leading(&contact);
 		if (parse_contacts(&contact, &ct) < 0) {
 			LM_WARN("INVITE or UPDATE w/ broken contact [%.*s] - not updating!\n",
-				contact.len, contact.s);
+				contact.len, redact_pii(contact.s));
 			return 0;
 		}
 		contact = ct->uri;
@@ -3088,7 +3089,7 @@ int dlg_validate_dialog( struct sip_msg* req, struct dlg_cell *dlg)
 		if (compare_uris(rr_uri,0,&leg->contact,0))
 		{
 			LM_ERR("failed to validate remote contact: dlg=[%.*s] , req=[%.*s]\n",
-					leg->contact.len,leg->contact.s,rr_uri->len,rr_uri->s);
+					leg->contact.len,redact_pii(leg->contact.s),rr_uri->len,redact_pii(rr_uri->s));
 			return -2;
 		}
 	}
@@ -3131,8 +3132,8 @@ int dlg_validate_dialog( struct sip_msg* req, struct dlg_cell *dlg)
 			if (compare_uris(&route_uris[i],0,&leg->route_uris[i],0))
 			{
 				LM_ERR("Check failed for route number %d. req=[%.*s],dlg=[%.*s]\n",
-						i,route_uris[i].len,route_uris[i].s,leg->route_uris[i].len,
-						leg->route_uris[i].s);
+						i,route_uris[i].len,redact_pii(route_uris[i].s),leg->route_uris[i].len,
+						redact_pii(leg->route_uris[i].s));
 				return -3;
 			}
 		}

--- a/modules/dialog/dlg_handlers.h
+++ b/modules/dialog/dlg_handlers.h
@@ -29,6 +29,7 @@
 #include "../../str.h"
 #include "../../pvar.h"
 #include "../../ut.h"
+#include "../../redact_pii.h"
 #include "../tm/t_hooks.h"
 #include "dlg_timer.h"
 
@@ -189,7 +190,7 @@ static inline int pre_match_parse( struct sip_msg *req, str *callid,
 
 	if (parse_from_header(req)<0 || get_from(req)->tag_value.len==0) {
 		LM_ERR("failed to get From header(%.*s) (hdr=%p,parsed=%p,tag_len=%d) "
-			"callid=<%.*s>\n",req->from->body.len, req->from->body.s,
+			"callid=<%.*s>\n",req->from->body.len, redact_pii(req->from->body.s),
 			req->from, req->from?req->from->parsed:NULL,
 			req->from?(req->from->parsed?get_from(req)->tag_value.len:0):0,
 			req->callid->body.len, req->callid->body.s);

--- a/modules/dialog/dlg_hash.c
+++ b/modules/dialog/dlg_hash.c
@@ -40,6 +40,7 @@
 #include "dlg_db_handler.h"
 #include "../../evi/evi_params.h"
 #include "../../evi/evi_modules.h"
+#include "../../redact_pii.h"
 
 #define MAX_LDG_LOCKS  2048
 #define MIN_LDG_LOCKS  2
@@ -425,7 +426,7 @@ static inline int translate_contact_ipport( str *ct, const struct socket_info *s
 
 	if (parse_uri( c->uri.s, c->uri.len, &puri)<0) {
 		LM_ERR("failed to parsed URI in contact <%.*s>\n",
-			c->uri.len, c->uri.s);
+			c->uri.len, redact_pii(c->uri.s));
 		goto error;
 	}
 	hostport.s = puri.host.s;

--- a/modules/dispatcher/dispatch.c
+++ b/modules/dispatcher/dispatch.c
@@ -53,6 +53,8 @@
 #include "ds_bl.h"
 #include "ds_clustering.h"
 
+#include "../../redact_pii.h"
+
 #define DS_TABLE_VERSION	9
 
 extern ds_partition_t *partitions;
@@ -2435,7 +2437,7 @@ int ds_is_in_list(struct sip_msg *_m, str *_ip, int port, int set,
 	char *pattern = NULL;
 
 	if (!(ip = str2ip(_ip)) && !(ip = str2ip6(_ip))) {
-		LM_ERR("IP val is not IP <%.*s>\n", _ip->len, _ip->s);
+		LM_ERR("IP val is not IP <%.*s>\n", _ip->len, redact_pii(_ip->s));
 		return -1;
 	}
 
@@ -2974,7 +2976,7 @@ int ds_push_script_attrs(struct sip_msg *_m, str *script_attrs,
 	int j,k;
 
 	if (!(ip = str2ip(_ip)) && !(ip = str2ip6(_ip))) {
-		LM_ERR("IP val is not IP <%.*s>\n",_ip->len,_ip->s);
+		LM_ERR("IP val is not IP <%.*s>\n",_ip->len,redact_pii(_ip->s));
 		return -1;
 	}
 

--- a/modules/domainpolicy/domainpolicy.c
+++ b/modules/domainpolicy/domainpolicy.c
@@ -37,6 +37,7 @@
 #include "../../route.h"
 #include "../../ip_addr.h"
 #include "../../socket_info.h"
+#include "../../redact_pii.h"
 
 #include "../../resolve.h"
 #include "../../regexp.h"
@@ -454,7 +455,7 @@ int dp_can_connect_str(str *domain, int rec_level) {
 
     if (rec_level > MAX_DDDS_RECURSIONS) {
     	LM_ERR("too many indirect NAPTRs. Aborting at %.*s.\n", domain->len,
-				ZSW(domain->s));
+				redact_pii(domain->s));
 		return(DP_DDDS_RET_DNSERROR);
     }
 
@@ -576,7 +577,7 @@ int dp_can_connect_str(str *domain, int rec_level) {
 	     */
 	    if (next_naptr && (next_naptr->order == naptr->order) && IS_D2PNAPTR(next_naptr)) {
 	    	LM_ERR("non-terminal NAPTR needs to be the only one "
-					"with this order %.*s.\n", domain->len, ZSW(domain->s));
+					"with this order %.*s.\n", domain->len, redact_pii(domain->s));
 
 		return(DP_DDDS_RET_DNSERROR);
 	    }
@@ -606,7 +607,7 @@ int dp_can_connect_str(str *domain, int rec_level) {
 	 */
 	if ((naptr->flags_len != 1) || (tolower(naptr->flags[0]) != 'u')) {
 	    LM_ERR("terminal NAPTR needs flag = 'u' and not '%.*s'.\n",
-					(int)naptr->flags_len, ZSW(naptr->flags));
+					(int)naptr->flags_len, redact_pii(naptr->flags));
 		/*
 		 * It's not that clear what we should do now: Ignore this records or regard it as failed.
 		 * We go with "ignore" for now.
@@ -694,7 +695,7 @@ int dp_can_connect(struct sip_msg* _msg, char* _s1, char* _s2) {
 	memcpy(domain.s, _msg->parsed_uri.host.s, domain.len);
 	domainname[domain.len] = '\0';
 
-	LM_DBG("domain is %.*s.\n", domain.len, ZSW(domain.s));
+	LM_DBG("domain is %.*s.\n", domain.len, redact_pii(domain.s));
 
 	ret = dp_can_connect_str(&domain,0);
 	LM_DBG("returning %d.\n", ret);
@@ -737,7 +738,7 @@ int dp_apply_policy(struct sip_msg* _msg, char* _s1, char* _s2) {
 			_msg->force_send_socket = si;
 		} else {
 			LM_WARN("could not find socket for"
-					"send_socket '%.*s'\n", val.s.len, ZSW(val.s.s));
+					"send_socket '%.*s'\n", val.s.len, redact_pii(val.s.s));
 		}
 	} else {
 		LM_DBG("send_socket_avp not found\n");
@@ -905,7 +906,7 @@ int dp_apply_policy(struct sip_msg* _msg, char* _s1, char* _s2) {
 	duri_str.len = at - duri_str.s;
 	LM_DBG("new DURI is '%.*s'\n",duri_str.len, ZSW(duri_str.s));
 	if (set_dst_uri(_msg, &duri_str) < 0) {
-		LM_ERR("Cannot set destination uri %.*s!\n", duri_str.len, ZSW(duri_str.s));
+		LM_ERR("Cannot set destination uri %.*s!\n", duri_str.len, redact_pii(duri_str.s));
 		return -1;
 	}
 

--- a/modules/drouting/drouting.c
+++ b/modules/drouting/drouting.c
@@ -31,6 +31,7 @@
 #include "../../ut.h"
 #include "../../lib/csv.h"
 #include "../../status_report.h"
+#include "../../redact_pii.h"
 
 #include "dr_load.h"
 #include "prefix_tree.h"
@@ -4404,7 +4405,7 @@ static int _uri_to_ip_port(str *uri, struct ip_addr *ip, int *port, int *proto)
 
 	memset( &puri, 0, sizeof(struct sip_uri));
 	if (parse_uri(uri->s, uri->len, &puri)!=0) {
-		LM_ERR("invalid sip uri <%.*s>\n", uri->len, uri->s);
+		LM_ERR("invalid sip uri <%.*s>\n", uri->len, redact_pii(uri->s));
 		return -1;
 	}
 
@@ -4478,7 +4479,7 @@ static int dr_is_gw(struct sip_msg* msg, str *uri, int *type, long flags,
 	int proto;
 
 	if (_uri_to_ip_port( uri, &ip, &port, &proto)!=0) {
-		LM_ERR("failed to extract IP/port from uri <%.*s>\n", uri->len,uri->s);
+		LM_ERR("failed to extract IP/port from uri <%.*s>\n", uri->len,redact_pii(uri->s));
 		return -1;
 	}
 

--- a/modules/drouting/routing.c
+++ b/modules/drouting/routing.c
@@ -37,6 +37,7 @@
 #include "parse.h"
 #include "dr_cb.h"
 #include "dr_cb_sorting.h"
+#include "../../redact_pii.h"
 
 
 #define is_valid_gw_char(_c) \
@@ -701,11 +702,11 @@ add_dst(
 	if (proxy==NULL) {
 		if(dr_force_dns) {
 			LM_ERR("cannot resolve <%.*s>\n",
-					uri.host.len, uri.host.s);
+					uri.host.len, redact_pii(uri.host.s));
 			goto err_exit;
 		} else {
 			LM_DBG("cannot resolve <%.*s> - won't be used"
-					" by is_from_gw()\n", uri.host.len, uri.host.s);
+					" by is_from_gw()\n", uri.host.len, redact_pii(uri.host.s));
 			goto done;
 		}
 	}

--- a/modules/enum/enum.c
+++ b/modules/enum/enum.c
@@ -35,6 +35,7 @@
 #include "../../regexp.h"
 #include "../../pvar.h"
 #include "../../mod_fix.h"
+#include "../../redact_pii.h"
 
 /*
  * Input: E.164 number w/o leading +
@@ -348,7 +349,7 @@ int is_from_user_enum(struct sip_msg* _msg, str* suffix, str* service)
 			if(parse_uri(result.s, result.len, &luri) < 0)
 			{
 				LM_ERR("Parsing of URI <%.*s> failed\n",
-				       result.len, result.s);
+				       result.len, redact_pii(result.s));
 				free_rdata_list(head); /*clean up*/
 				return -7;
 			}
@@ -362,7 +363,7 @@ int is_from_user_enum(struct sip_msg* _msg, str* suffix, str* service)
 				(luri.type==SIPS_URI_T)?1:0 , 0);
 			if (he == NULL){
 				LM_ERR("Resolving URI <%.*s> failed\n",
-					   result.len, result.s);
+					   result.len, redact_pii(result.s));
 				free_rdata_list(head); /*clean up*/
 				return -9;
 			}
@@ -607,7 +608,7 @@ int do_query(struct sip_msg* _msg, char *user, char *name, str *service) {
 	    new_result.len = MAX_URI_SIZE;
 	    if (add_uri_param(&result, &param, &new_result) == 0) {
 		LM_ERR("Parsing of URI <%.*s> failed\n",
-		       result.len, result.s);
+		       result.len, redact_pii(result.s));
 		continue;
 	    }
 	    if (new_result.len > 0) {

--- a/modules/event_routing/ebr_data.c
+++ b/modules/event_routing/ebr_data.c
@@ -27,6 +27,7 @@
 #include "../../action.h"
 #include "../../route.h"
 #include "../../evi/evi_modules.h"
+#include "../../redact_pii.h"
 #include "../tm/tm_load.h"
 
 #include "ebr_data.h"
@@ -404,7 +405,7 @@ static inline int ebr_filter_match_evp(const ebr_filter *filter,
 
 		if (parse_uri(e_param->val.s.s, e_param->val.s.len, &puri) != 0) {
 			LM_ERR("failed to parse URI: '%.*s'\n",
-			       e_param->val.s.len, e_param->val.s.s);
+			       e_param->val.s.len, redact_pii(e_param->val.s.s));
 			return 0;
 		}
 

--- a/modules/mid_registrar/lookup.c
+++ b/modules/mid_registrar/lookup.c
@@ -34,6 +34,7 @@
 #include "../../dset.h"
 #include "../../mod_fix.h"
 #include "../../lib/reg/common.h"
+#include "../../redact_pii.h"
 
 #include "../usrloc/usrloc.h"
 #include "../usrloc/urecord.h"
@@ -86,7 +87,7 @@ int mid_reg_lookup(struct sip_msg *req, udomain_t *d,
 
 	if (parse_uri(uri->s, uri->len, &puri) < 0) {
 		LM_ERR("failed to parse R-URI <%.*s>, ci: %.*s\n", uri->len,
-		       uri->s, req->callid->body.len, req->callid->body.s);
+		       redact_pii(uri->s), req->callid->body.len, req->callid->body.s);
 		return -1;
 	}
 
@@ -95,20 +96,20 @@ int mid_reg_lookup(struct sip_msg *req, udomain_t *d,
 		if (pos < 0) {
 			LM_ERR("failed to locate our ';%.*s=' param in %sURI '%.*s', "
 			       "ci = %.*s!\n", ctid_param.len, ctid_param.s,
-			       uri ? "" : "R-", uri->len, uri->s, req->callid->body.len,
+			       uri ? "" : "R-", uri->len, redact_pii(uri->s), req->callid->body.len,
 			       req->callid->body.s);
 			return -1;
 		}
 		if (str2int64(&puri.u_val[pos], &contact_id) != 0) {
 			LM_ERR("invalid contact_id in %sURI '%.*s', ci: %.*s\n",
-			       uri ? "" : "R-", uri->len, uri->s, req->callid->body.len,
+			       uri ? "" : "R-", uri->len, redact_pii(uri->s), req->callid->body.len,
 			       req->callid->body.s);
 			return -1;
 		}
 	} else {
 		if (str2int64(&puri.user, &contact_id) != 0) {
 			LM_ERR("invalid contact_id in %sURI '%.*s', ci: %.*s\n",
-			       uri ? "" : "R-", uri->len, uri->s, req->callid->body.len,
+			       uri ? "" : "R-", uri->len, redact_pii(uri->s), req->callid->body.len,
 			       req->callid->body.s);
 			return -1;
 		}

--- a/modules/mid_registrar/save.c
+++ b/modules/mid_registrar/save.c
@@ -40,6 +40,7 @@
 #include "../../parser/parse_supported.h"
 #include "../../parser/parse_allow.h"
 #include "../../dset.h"
+#include "../../redact_pii.h"
 
 #include "../../parser/parse_from.h"
 #include "../../status_report.h"
@@ -570,7 +571,7 @@ void overwrite_contact_expirations(struct sip_msg *req, struct mid_reg_info *mri
 		if (e != new_expires &&
 		    replace_expires(c, req, new_expires, &exp_header_done) != 0) {
 			LM_ERR("failed to replace expires for ct '%.*s'\n",
-			       c->uri.len, c->uri.s);
+			       c->uri.len, redact_pii(c->uri.s));
 		}
 	}
 }
@@ -989,7 +990,7 @@ static contact_t *match_contact(ucontact_id ctid, struct sip_msg *msg)
 
 		if (parse_uri(c->uri.s, c->uri.len, &puri) < 0) {
 			LM_ERR("failed to parse reply contact uri <%.*s>\n",
-			       c->uri.len, c->uri.s);
+			       c->uri.len, redact_pii(c->uri.s));
 			return NULL;
 		}
 
@@ -1359,7 +1360,7 @@ static inline int save_restore_rpl_contacts(struct sip_msg *req,
 		if (hdr->type == HDR_CONTACT_T &&
 		     !del_lump(rpl, hdr->name.s - rpl->buf, hdr->len, HDR_CONTACT_T)) {
 			LM_ERR("failed to delete contact '%.*s'\n", hdr->name.len,
-			       hdr->name.s);
+			       redact_pii(hdr->name.s));
 			goto error;
 		}
 	}
@@ -1496,7 +1497,7 @@ update_usrloc:
 
 		if (pn_enable && pn_add_reply_purr(c) != 0)
 			LM_ERR("failed to add +sip.pnspurr for Contact: '%.*s'\n",
-			       ctmap->req_ct_uri.len, ctmap->req_ct_uri.s);
+			       ctmap->req_ct_uri.len, redact_pii(ctmap->req_ct_uri.s));
 
 		ctmap->uc = c;
 
@@ -1504,7 +1505,7 @@ update_usrloc:
 			/* parse contact uri to see if transport is TCP */
 			if (parse_uri(ctmap->req_ct_uri.s, ctmap->req_ct_uri.len, &uri)<0) {
 				LM_ERR("failed to parse contact <%.*s>\n",
-						ctmap->req_ct_uri.len, ctmap->req_ct_uri.s);
+						ctmap->req_ct_uri.len, redact_pii(ctmap->req_ct_uri.s));
 			} else if ( is_tcp_based_proto(uri.proto) ) {
 				if (e_max)
 					LM_WARN("multiple TCP contacts on single REGISTER\n");
@@ -1662,7 +1663,7 @@ static inline int save_restore_req_contacts(struct sip_msg *req,
 		if (!_c) {
 			if (ctmap->expires != 0)
 				LM_ERR("200 OK from main registrar is missing Contact '%.*s'\n",
-				       ctmap->req_ct_uri.len, ctmap->req_ct_uri.s);
+				       ctmap->req_ct_uri.len, redact_pii(ctmap->req_ct_uri.s));
 			goto update_usrloc;
 		}
 
@@ -1763,7 +1764,7 @@ update_usrloc:
 
 		if (pn_enable && pn_add_reply_purr(c) != 0)
 			LM_ERR("failed to add +sip.pnspurr for Contact: '%.*s'\n",
-			       ctmap->req_ct_uri.len, ctmap->req_ct_uri.s);
+			       ctmap->req_ct_uri.len, redact_pii(ctmap->req_ct_uri.s));
 
 		ctmap->uc = c;
 
@@ -1771,7 +1772,7 @@ update_usrloc:
 			/* parse contact uri to see if transport is TCP */
 			if (parse_uri(ctmap->req_ct_uri.s, ctmap->req_ct_uri.len, &uri)<0) {
 				LM_ERR("failed to parse contact <%.*s>\n",
-				       ctmap->req_ct_uri.len, ctmap->req_ct_uri.s);
+				       ctmap->req_ct_uri.len, redact_pii(ctmap->req_ct_uri.s));
 			} else if ( is_tcp_based_proto(uri.proto) ) {
 				if (e_max)
 					LM_WARN("multiple TCP contacts on single REGISTER\n");

--- a/modules/mmgeoip/mmgeoip.c
+++ b/modules/mmgeoip/mmgeoip.c
@@ -27,6 +27,7 @@
 #include "../../usr_avp.h"
 #include "../../mod_fix.h"
 #include "../../ut.h"
+#include "../../redact_pii.h"
 
 #include "mmgeoip.h"
 
@@ -143,7 +144,7 @@ static int mmg_lookup_cmd(struct sip_msg *msg, str *_fields, str *ipaddr_str,
 		if(rslt.s.len<0 || rslt.s.len>sizeof rslt_buf ||
 		add_avp(dstType|AVP_VAL_STR,dst_name,rslt)==-1 ) {
 			LM_ERR("Internal error processing field/IP '%s/%s'.\n",
-				token,ipaddr_buf);
+				token,redact_pii(ipaddr_buf));
 			geoip_free_lookup_res(lookup_res);
 			return -1;
 		}

--- a/modules/msrp_gateway/msrp_gateway.c
+++ b/modules/msrp_gateway/msrp_gateway.c
@@ -26,6 +26,7 @@
 #include "../../parser/parse_uri.h"
 #include "../../parser/parse_from.h"
 #include "../tm/tm_load.h"
+#include "../../redact_pii.h"
 
 #include "../msrp_ua/api.h"
 
@@ -531,12 +532,12 @@ static int msrpgw_answer(struct sip_msg *msg, str *key, str *content_types,
 
 	if (parse_uri(from->s, from->len, &sip_uri) < 0) {
 		LM_ERR("Not a valid sip uri in From param [%.*s]\n",
-			from->len, from->s);
+			from->len, redact_pii(from->s));
 		return -1;
 	}
 	if (parse_uri(to->s, to->len, &sip_uri) < 0) {
 		LM_ERR("Not a valid sip uri in To param [%.*s]\n",
-			to->len, to->s);
+			to->len, redact_pii(to->s));
 		return -1;
 	}
 
@@ -547,7 +548,7 @@ static int msrpgw_answer(struct sip_msg *msg, str *key, str *content_types,
 	}
 	if (parse_uri(ruri->s, ruri->len, &sip_uri) < 0) {
 		LM_ERR("Not a valid sip uri in RURI param [%.*s]\n",
-			ruri->len, ruri->s);
+			ruri->len, redact_pii(ruri->s));
 		return -1;
 	}
 

--- a/modules/nat_traversal/nat_traversal.c
+++ b/modules/nat_traversal/nat_traversal.c
@@ -47,6 +47,7 @@
 #include "../../parser/parse_uri.h"
 #include "../../parser/parse_expires.h"
 #include "../../parser/contact/parse_contact.h"
+#include "../../redact_pii.h"
 #include "../dialog/dlg_load.h"
 #include "../tm/tm_load.h"
 #include "clustering.h"
@@ -1994,7 +1995,7 @@ pv_parse_nat_contact_name(pv_spec_p sp, const str *in)
         }
         s = pv_parse_spec(in, nsp);
         if (s==NULL) {
-            LM_ERR("invalid name [%.*s]\n", in->len, in->s);
+            LM_ERR("invalid name [%.*s]\n", in->len, redact_pii(in->s));
             pv_spec_free(nsp);
             return -1;
         }

--- a/modules/nathelper/nathelper.c
+++ b/modules/nathelper/nathelper.c
@@ -72,6 +72,7 @@
 #include "../../parser/sdp/sdp_helpr_funcs.h"
 #include "../../parser/parse_content.h"
 #include "../../parser/contact/parse_contact.h"
+#include "../../redact_pii.h"
 #include "../usrloc/usrloc.h"
 #include "../usrloc/ul_mod.h"
 
@@ -427,7 +428,7 @@ static int get_natping_socket(char *socket,
 
 	he = sip_resolvehost( &host, port, (unsigned short*)(void*)&lproto, 0, 0);
 	if (he==0) {
-		LM_ERR("could not resolve hostname:\"%.*s\"\n", host.len, host.s);
+		LM_ERR("could not resolve hostname:\"%.*s\"\n", host.len, redact_pii(host.s));
 		return -1;
 	}
 	if (he->h_addrtype != AF_INET) {
@@ -1235,13 +1236,13 @@ replace_sdp_ip(struct sip_msg* msg, str *org_body, char *line, str *ip, int forc
 		if (extract_mediaip(&body1, &oldip, &pf,line) == -1)
 			break;
 		if (pf != AF_INET) {
-			LM_ERR("not an IPv4 address in '%s' SDP\n",line);
+			LM_ERR("not an IPv4 address in '%s' SDP\n",redact_pii(line));
 				return -1;
 			}
 		if (!pf1)
 			pf1 = pf;
 		else if (pf != pf1) {
-			LM_ERR("mismatching address families in '%s' SDP\n",line);
+			LM_ERR("mismatching address families in '%s' SDP\n",redact_pii(line));
 			return -1;
 		}
 		body2.s = oldip.s + oldip.len;
@@ -1250,14 +1251,14 @@ replace_sdp_ip(struct sip_msg* msg, str *org_body, char *line, str *ip, int forc
 					!(get_field_flag(line[0])&skip_oldip),
 					line[0], forcenulladdr) == -1) {
 					/*if flag set do not set oldmediaip field*/
-			LM_ERR("can't alter '%s' IP\n",line);
+			LM_ERR("can't alter '%s' IP\n",redact_pii(line));
 			return -1;
 		}
 		hasreplaced = 1;
 		body1 = body2;
 	}
 	if (!hasreplaced) {
-		LM_ERR("can't extract '%s' IP from the SDP\n",line);
+		LM_ERR("can't extract '%s' IP from the SDP\n",redact_pii(line));
 		return -1;
 	}
 

--- a/modules/osp/sipheader.c
+++ b/modules/osp/sipheader.c
@@ -40,6 +40,7 @@
 #include "../../parser/contact/parse_contact.h"
 #include "../../data_lump.h"
 #include "../../mem/mem.h"
+#include "../../redact_pii.h"
 #include "osp_mod.h"
 #include "destination.h"
 #include "timeapi.h"
@@ -149,7 +150,7 @@ void ospCopyStrToBuffer(
     if (source->len >= bufsize) {
         LM_ERR("buffer for copying '%.*s' is too small, will copy the first '%d' bytes\n",
             source->len,
-            source->s,
+            redact_pii(source->s),
             bufsize - 1);
         copybytes = bufsize;
     } else {
@@ -1094,7 +1095,7 @@ int ospGetOspToken(
             } else {
                 LM_ERR("failed to base64 decode token (%d)\n", errorcode);
                 LM_ERR("header '%.*s' length %d\n",
-                    hf->body.len, hf->body.s, hf->body.len);
+                    hf->body.len, redact_pii(hf->body.s), hf->body.len);
             }
         }
     } else {
@@ -1275,7 +1276,7 @@ int ospGetRouteParam(
         } else if (!(rt = (rr_t*)hf->parsed)) {
             LM_ERR("route headers are not parsed\n");
         } else if (parse_uri(rt->nameaddr.uri.s, rt->nameaddr.uri.len, &uri) != 0) {
-            LM_ERR("failed to parse the Route uri '%.*s'\n", rt->nameaddr.uri.len, rt->nameaddr.uri.s);
+            LM_ERR("failed to parse the Route uri '%.*s'\n", rt->nameaddr.uri.len, redact_pii(rt->nameaddr.uri.s));
         } else if (check_self(&uri.host, uri.port_no ? uri.port_no : SIP_PORT, PROTO_NONE) != 1) {
             LM_DBG("the Route uri is NOT mine\n");
             LM_DBG("host '%.*s' port '%d'\n", uri.host.len, uri.host.s, uri.port_no);
@@ -1584,7 +1585,7 @@ int ospGetNextHop(
                     } else {
                         LM_ERR("failed to parse route uri '%.*s'\n",
                             rt->nameaddr.uri.len,
-                            rt->nameaddr.uri.s);
+                            redact_pii(rt->nameaddr.uri.s));
                     }
                 }
                 if (found == 1) {

--- a/modules/proto_bin/proto_bin.c
+++ b/modules/proto_bin/proto_bin.c
@@ -41,6 +41,7 @@
 #include "../../bin_interface.h"
 #include "proto_bin.h"
 #include "../../ut.h"
+#include "../../redact_pii.h"
 
 
 static int mod_init(void);
@@ -314,7 +315,7 @@ static int bin_read_req(struct tcp_connection* con, int* bytes_read){
 	if (req->error!=TCP_REQ_OK){
 		LM_ERR("bad request, state=%d, error=%d "
 				  "buf:\n%.*s\nparsed:\n%d\n", req->state, req->error,
-				  (int)(req->pos-req->buf), req->buf,
+				  (int)(req->pos-req->buf), redact_pii(req->buf),
 				  (int)(req->parsed-req->buf));
 		LM_DBG("- received from: port %d\n", con->rcv.src_port);
 		print_ip("- received from: ip ",&con->rcv.src_ip, "\n");

--- a/modules/proto_bins/proto_bins.c
+++ b/modules/proto_bins/proto_bins.c
@@ -34,6 +34,7 @@
 #include "../../pt.h"
 #include "../../bin_interface.h"
 #include "../../ut.h"
+#include "../../redact_pii.h"
 
 #include "../tls_mgm/api.h"
 #include "../tls_mgm/tls_trace_common.h"
@@ -585,8 +586,8 @@ again:
 	if (req->error!=TCP_REQ_OK){
 		LM_ERR("bad request, state=%d, error=%d "
 				  "buf:\n%.*s\nparsed:\n%.*s\n", req->state, req->error,
-				  (int)(req->pos-req->buf), req->buf,
-				  (int)(req->parsed-req->start), req->start);
+				  (int)(req->pos-req->buf), redact_pii(req->buf),
+				  (int)(req->parsed-req->start), redact_pii(req->start));
 		LM_DBG("- received from: port %d\n", con->rcv.src_port);
 		print_ip("- received from: ip ",&con->rcv.src_ip, "\n");
 		goto error;

--- a/modules/proto_hep/proto_hep.c
+++ b/modules/proto_hep/proto_hep.c
@@ -43,6 +43,7 @@
 #include "../../net/proto_tcp/tcp_common_defs.h"
 #include "../../pt.h"
 #include "../../ut.h"
+#include "../../redact_pii.h"
 #include "../compression/compression_api.h"
 #include "../tls_mgm/api.h"
 #include "hep.h"
@@ -912,8 +913,8 @@ again:
 	if (req->error != TCP_REQ_OK){
 		LM_ERR("bad request, state=%d, error=%d "
 			  "buf:\n%.*s\nparsed:\n%.*s\n", req->state, req->error,
-			  (int)(req->pos-req->buf), req->buf,
-			  (int)(req->parsed-req->start), req->start);
+			  (int)(req->pos-req->buf), redact_pii(req->buf),
+			  (int)(req->parsed-req->start), redact_pii(req->start));
 		LM_DBG("- received from: port %d\n", con->rcv.src_port);
 		print_ip("- received from: ip ", &con->rcv.src_ip, "\n");
 		goto error;

--- a/modules/proto_msrp/msrp_common.c
+++ b/modules/proto_msrp/msrp_common.c
@@ -32,6 +32,7 @@
 #include "../../net/trans_trace.h"
 #include "../../net/tcp_common.h"
 #include "../../timer.h"
+#include "../../redact_pii.h"
 #include "msrp_handler.h"
 #include "msrp_plain.h"
 #include "msrp_common.h"
@@ -549,8 +550,8 @@ again:
 	if (req->tcp.error!=TCP_REQ_OK){
 		LM_ERR("bad request, state=%d, error=%d "
 				  "buf:\n%.*s\nparsed:\n%.*s\n", req->state, req->tcp.error,
-				  (int)(req->tcp.pos-req->tcp.buf), req->tcp.buf,
-				  (int)(req->tcp.parsed-req->tcp.start), req->tcp.start);
+				  (int)(req->tcp.pos-req->tcp.buf), redact_pii(req->tcp.buf),
+				  (int)(req->tcp.parsed-req->tcp.start), redact_pii(req->tcp.start));
 		LM_DBG("- received from: port %d\n", con->rcv.src_port);
 		print_ip("- received from: ip ",&con->rcv.src_ip, "\n");
 		goto error;

--- a/modules/proto_msrp/msrp_handler.c
+++ b/modules/proto_msrp/msrp_handler.c
@@ -21,6 +21,7 @@
 
 #include <fnmatch.h>
 #include "../../mem/mem.h"
+#include "../../redact_pii.h"
 #include "msrp_parser.h"
 #include "msrp_signaling.h"
 #include "msrp_handler.h"
@@ -197,7 +198,7 @@ int handle_msrp_msg(char* buf, int len, struct msrp_firstline *fl, str *body,
 
 		if (_dispatch_req_to_handler( msg )<0) {
 			LM_ERR("Request for [%.*s] not handled by any handler :(\n",
-				msg->to_path->body.len, msg->to_path->body.s);
+				msg->to_path->body.len, redact_pii(msg->to_path->body.s));
 			goto parse_error;  // FIXME a 4xx reply ??
 		}
 

--- a/modules/proto_smpp/proto_smpp.c
+++ b/modules/proto_smpp/proto_smpp.c
@@ -43,6 +43,7 @@
 #include "../../receive.h"
 #include "../tm/tm_load.h"
 #include "../../parser/parse_from.h"
+#include "../../redact_pii.h"
 
 #include "proto_smpp.h"
 #include "utils.h"
@@ -402,8 +403,8 @@ static int smpp_read_req(struct tcp_connection* con, int* bytes_read)
 	if (req->error!=TCP_REQ_OK){
 		LM_ERR("bad request, state=%d, error=%d "
 				  "buf:\n%.*s\nparsed:\n%.*s\n", req->state, req->error,
-				  (int)(req->pos-req->buf), req->buf,
-				  (int)(req->parsed-req->start), req->start);
+				  (int)(req->pos-req->buf), redact_pii(req->buf),
+				  (int)(req->parsed-req->start), redact_pii(req->start));
 		LM_DBG("- received from: port %d\n", con->rcv.src_port);
 		print_ip("- received from: ip ",&con->rcv.src_ip, "\n");
 		goto error;

--- a/modules/proto_tls/proto_tls.c
+++ b/modules/proto_tls/proto_tls.c
@@ -60,6 +60,7 @@
 #include "../../pt.h"
 #include "../../parser/msg_parser.h"
 #include "../../pvar.h"
+#include "../../redact_pii.h"
 
 #include "../../net/proto_tcp/tcp_common_defs.h"
 #include "../tls_mgm/api.h"
@@ -808,8 +809,8 @@ again:
 	if (req->error!=TCP_REQ_OK){
 		LM_ERR("bad request, state=%d, error=%d "
 				  "buf:\n%.*s\nparsed:\n%.*s\n", req->state, req->error,
-				  (int)(req->pos-req->buf), req->buf,
-				  (int)(req->parsed-req->start), req->start);
+				  (int)(req->pos-req->buf), redact_pii(req->buf),
+				  (int)(req->parsed-req->start), redact_pii(req->start));
 		LM_DBG("- received from: port %d\n", con->rcv.src_port);
 		print_ip("- received from: ip ",&con->rcv.src_ip, "\n");
 		goto error;

--- a/modules/proto_ws/ws_handshake_common.h
+++ b/modules/proto_ws/ws_handshake_common.h
@@ -29,6 +29,7 @@
 #include <pthread.h>
 
 #include "../../ip_addr.h"
+#include "../../redact_pii.h"
 
 #define HTTP_SEP			"\r\n"
 #define HTTP_SEP_LEN		(sizeof(HTTP_SEP) - 1)
@@ -292,8 +293,8 @@ static inline int ws_client_handshake(struct tcp_connection *con)
 		if (req->error!=TCP_REQ_OK){
 			LM_ERR("bad request, state=%d, error=%d "
 					  "buf:\n%.*s\nparsed:\n%.*s\n", req->state, req->error,
-					  (int)(req->pos-req->buf), req->buf,
-					  (int)(req->parsed-req->start), req->start);
+					  (int)(req->pos-req->buf), redact_pii(req->buf),
+					  (int)(req->parsed-req->start), redact_pii(req->start));
 			LM_DBG("- received from: port %d\n", con->rcv.src_port);
 			print_ip("- received from: ip ",&con->rcv.src_ip, "\n");
 			goto error;
@@ -451,8 +452,8 @@ static int ws_server_handshake(struct tcp_connection *con)
 	if (req->error!=TCP_REQ_OK){
 		LM_ERR("bad request, state=%d, error=%d "
 				  "buf:\n%.*s\nparsed:\n%.*s\n", req->state, req->error,
-				  (int)(req->pos-req->buf), req->buf,
-				  (int)(req->parsed-req->start), req->start);
+				  (int)(req->pos-req->buf), redact_pii(req->buf),
+				  (int)(req->parsed-req->start), redact_pii(req->start));
 		LM_DBG("- received from: port %d\n", con->rcv.src_port);
 		print_ip("- received from: ip ",&con->rcv.src_ip, "\n");
 		goto error;

--- a/modules/registrar/lookup.c
+++ b/modules/registrar/lookup.c
@@ -37,6 +37,7 @@
 #include "../../parser/parse_rr.h"
 #include "../../parser/parse_from.h"
 #include "../../lib/reg/common.h"
+#include "../../redact_pii.h"
 #include "../usrloc/usrloc.h"
 
 #include "reg_mod.h"
@@ -364,12 +365,12 @@ int is_ip_registered(struct sip_msg* _m, void* _d, str* _a, pv_spec_t *ip_spec,p
 		/* extract the IP from contact */
 		if (parse_uri(uri.s, uri.len, &tmp_uri) < 0) {
 			LM_ERR("contact [%.*s] is not valid! Will not store it!\n",
-				  uri.len, uri.s);
+				  uri.len, redact_pii(uri.s));
 		}
 		if ( (ipp=str2ip(&tmp_uri.host))==NULL &&
 		(ipp=str2ip6(&tmp_uri.host))==NULL ) {
 			LM_ERR("failed to get IP from contact/received <%.*s>, skipping\n",
-				tmp_uri.host.len, tmp_uri.host.s);
+				tmp_uri.host.len, redact_pii(tmp_uri.host.s));
 			continue;
 		}
 		ip = *ipp;
@@ -380,7 +381,7 @@ int is_ip_registered(struct sip_msg* _m, void* _d, str* _a, pv_spec_t *ip_spec,p
 			if ( (ipp=str2ip(&pv_host))==NULL &&
 			(ipp=str2ip6(&pv_host))==NULL ) {
 				LM_ERR("param IP  <%.*s> is not valid, skipping\n",
-					pv_host.len, pv_host.s);
+					pv_host.len, redact_pii(pv_host.s));
 				continue;
 			}
 
@@ -411,7 +412,7 @@ int is_ip_registered(struct sip_msg* _m, void* _d, str* _a, pv_spec_t *ip_spec,p
 				if ( (ipp=str2ip(&pv_host))==NULL &&
 				(ipp=str2ip6(&pv_host))==NULL ) {
 					LM_ERR("param IP  <%.*s> is not valid, skipping\n",
-						pv_host.len, pv_host.s);
+						pv_host.len, redact_pii(pv_host.s));
 					continue;
 				}
 

--- a/modules/registrar/reply.c
+++ b/modules/registrar/reply.c
@@ -40,6 +40,7 @@
 #include "../../parser/parse_supported.h"
 #include "../../data_lump_rpl.h"
 #include "../../lib/reg/common.h"
+#include "../../redact_pii.h"
 
 #include "../usrloc/usrloc.h"
 
@@ -521,7 +522,7 @@ int send_reply(struct sip_msg* _m, unsigned int _flags)
 	}
 
 	if (sigb.reply(_m, code, &msg, NULL) == -1) {
-		LM_ERR("failed to send %ld %.*s\n", code, msg.len,msg.s);
+		LM_ERR("failed to send %ld %.*s\n", code, msg.len,redact_pii(msg.s));
 		return -1;
 	} else return 0;
 }

--- a/modules/registrar/save.c
+++ b/modules/registrar/save.c
@@ -59,6 +59,7 @@
 #include "../../mod_fix.h"
 #include "../../data_lump.h"
 #include "../../lib/reg/common.h"
+#include "../../redact_pii.h"
 
 #include "../usrloc/usrloc.h"
 
@@ -295,13 +296,13 @@ static inline int insert_contacts(struct sip_msg* _m, contact_t* _c,
 
 		if (pn_enable && pn_add_reply_purr(c) != 0)
 			LM_ERR("failed to add +sip.pnspurr for Contact: '%.*s'\n",
-			       _c->uri.len, _c->uri.s);
+			       _c->uri.len, redact_pii(_c->uri.s));
 
 		if (tcp_check) {
 			/* parse contact uri to see if transport is TCP */
 			if (parse_uri( _c->uri.s, _c->uri.len, &uri)<0) {
 				LM_ERR("failed to parse contact <%.*s>\n",
-						_c->uri.len, _c->uri.s);
+						_c->uri.len, redact_pii(_c->uri.s));
 			} else if ( is_tcp_based_proto(uri.proto) ) {
 				if (e_max) {
 					LM_WARN("multiple TCP contacts on single REGISTER\n");
@@ -528,13 +529,13 @@ static inline int update_contacts(struct sip_msg* _m, urecord_t* _r,
 
 		if (pn_enable && pn_add_reply_purr(c) != 0)
 			LM_ERR("failed to add +sip.pnspurr for Contact: '%.*s'\n",
-			       _c->uri.len, _c->uri.s);
+			       _c->uri.len, redact_pii(_c->uri.s));
 
 		if (tcp_check) {
 			/* parse contact uri to see if transport is TCP */
 			if (parse_uri( _c->uri.s, _c->uri.len, &uri)<0) {
 				LM_ERR("failed to parse contact <%.*s>\n",
-						_c->uri.len, _c->uri.s);
+						_c->uri.len, redact_pii(_c->uri.s));
 			} else if (is_tcp_based_proto(uri.proto)) {
 				if (e_max>0) {
 					LM_WARN("multiple TCP contacts on single REGISTER\n");
@@ -962,7 +963,7 @@ int _remove(struct sip_msg *msg, void *udomain, str *aor_uri, str *match_ct,
 		he = sip_resolvehost(match_next_hop, &delete_port, NULL, 0, NULL);
 		if (!he) {
 			LM_ERR("cannot resolve given host: '%.*s'\n",
-			       match_next_hop->len, match_next_hop->s);
+			       match_next_hop->len, redact_pii(match_next_hop->s));
 			ret = E_UNSPEC;
 			goto out_unlock;
 		}
@@ -991,8 +992,8 @@ int _remove(struct sip_msg *msg, void *udomain, str *aor_uri, str *match_ct,
 		                     &contact->next_hop.proto, 0, NULL);
 		if (!he) {
 			LM_ERR("failed to resolve next hop %.*s of contact '%.*s'\n",
-				contact->next_hop.name.len, contact->next_hop.name.s,
-				contact->c.len, contact->c.s);
+				contact->next_hop.name.len, redact_pii(contact->next_hop.name.s),
+				contact->c.len, redact_pii(contact->c.s));
 			continue;
 		}
 
@@ -1053,8 +1054,8 @@ int _remove_ip_port_urecord(urecord_t* record, str *ip, int* port)
 		                     &contact->next_hop.proto, 0, NULL);
 		if (!he) {
 			LM_ERR("failed to resolve next hop %.*s of contact '%.*s'\n",
-				contact->next_hop.name.len, contact->next_hop.name.s,
-				contact->c.len, contact->c.s);
+				contact->next_hop.name.len, redact_pii(contact->next_hop.name.s),
+				contact->c.len, redact_pii(contact->c.s));
 			continue;
 		}
 

--- a/modules/rest_client/rest_client.c
+++ b/modules/rest_client/rest_client.c
@@ -40,6 +40,7 @@
 #include "rest_client.h"
 #include "rest_methods.h"
 #include "../../pt.h"
+#include "../../redact_pii.h"
 
 /*
  * Module parameters
@@ -421,7 +422,7 @@ int tr_rest_eval(struct sip_msg *msg, tr_param_t *tp, int subtype,
 		curl_out = curl_easy_escape(sync_handle, input_str.s, input_str.len);
 		if (!curl_out) {
 			LM_ERR("failed to execute curl_easy_escape on '%.*s'\n",
-			       input_str.len, input_str.s);
+			       input_str.len, redact_pii(input_str.s));
 			goto error;
 		}
 
@@ -431,7 +432,7 @@ int tr_rest_eval(struct sip_msg *msg, tr_param_t *tp, int subtype,
 		curl_out = curl_escape(input_str.s, input_str.len);
 		if (!curl_out) {
 			LM_ERR("failed to execute curl_escape on '%.*s'\n",
-			       input_str.len, input_str.s);
+			       input_str.len, redact_pii(input_str.s));
 			goto error;
 		}
 
@@ -462,7 +463,7 @@ int tr_rest_eval(struct sip_msg *msg, tr_param_t *tp, int subtype,
 		curl_out = curl_easy_unescape(sync_handle, input_str.s, input_str.len, NULL);
 		if (!curl_out) {
 			LM_ERR("failed to execute curl_easy_unescape on '%.*s'\n",
-			       input_str.len, input_str.s);
+			       input_str.len, redact_pii(input_str.s));
 			goto error;
 		}
 
@@ -472,7 +473,7 @@ int tr_rest_eval(struct sip_msg *msg, tr_param_t *tp, int subtype,
 		curl_out = curl_unescape(input_str.s, input_str.len);
 		if (!curl_out) {
 			LM_ERR("failed to execute curl_unescape on '%.*s'\n",
-			       input_str.len, input_str.s);
+			       input_str.len, redact_pii(input_str.s));
 			goto error;
 		}
 

--- a/modules/rls/rls.c
+++ b/modules/rls/rls.c
@@ -42,6 +42,7 @@
 #include "../../mem/mem.h"
 #include "../../mem/shm_mem.h"
 #include "../../mi/mi.h"
+#include "../../redact_pii.h"
 #include "../tm/tm_load.h"
 #include "../signaling/signaling.h"
 #include "../presence/bind_presence.h"
@@ -868,7 +869,7 @@ mi_response_t *mi_update_subscriptions(const mi_params_t *params,
 
 	if (parse_uri(uri.s, uri.len, &parsed_uri) < 0)
 	{
-		LM_ERR("bad uri: %.*s\n", uri.len, uri.s);
+		LM_ERR("bad uri: %.*s\n", uri.len, redact_pii(uri.s));
 		return 0;
 	}
 

--- a/modules/rls/subscribe.c
+++ b/modules/rls/subscribe.c
@@ -38,6 +38,7 @@
 #include "../../parser/parse_supported.h"
 #include "../../parser/contact/parse_contact.h"
 #include "../../parser/parse_rr.h"
+#include "../../redact_pii.h"
 #include "../presence/subscribe.h"
 #include "../presence/utils_func.h"
 #include "../presence/hash.h"
@@ -813,12 +814,12 @@ int send_resource_subs(char* uri, void* param)
 	send_sock = uri2sock(NULL, dest_uri, &dummy_su, PROTO_NONE);
 	if (send_sock == NULL) {
 		// if defined, s->outbound_proxy->s is null terminated because it is the presence_server modparam
-		LM_ERR("Failed to get sending socket for %s (outbound proxy = %s)\n", uri, s->outbound_proxy ? s->outbound_proxy->s : "none");
+		LM_ERR("Failed to get sending socket for %s (outbound proxy = %s)\n", redact_pii(uri), s->outbound_proxy ? s->outbound_proxy->s : "none");
 		return 1;
 	}
 
 	if (get_local_contact(send_sock, &contact_user, &contact) < 0) {
-		LM_ERR("Failed to get local contact for %s\n", uri);
+		LM_ERR("Failed to get local contact for %s\n", redact_pii(uri));
 		return 1;
 	}
 
@@ -846,7 +847,7 @@ int send_resource_subs(char* uri, void* param)
 	{
 		LM_WARN("%.*s has %.*s multiple times in the same resource list\n",
 				s->watcher_uri->len, s->watcher_uri->s,
-				s->pres_uri->len, s->pres_uri->s);
+				s->pres_uri->len, redact_pii(s->pres_uri->s));
 		return 1;
 	}
 

--- a/modules/rr/loose.c
+++ b/modules/rr/loose.c
@@ -51,6 +51,7 @@
 #include "../../parser/parse_from.h"
 #include "../../mem/mem.h"
 #include "../../dset.h"
+#include "../../redact_pii.h"
 #include "loose.h"
 #include "rr_cb.h"
 #include "rr_mod.h"
@@ -445,7 +446,7 @@ static inline int after_strict(struct sip_msg* _m)
 		} else {
 			if (enable_socket_mismatch_warning)
 				LM_WARN("no socket found to match 2nd RR [%d][%.*s:%d]\n",
-					puri.proto, puri.host.len, puri.host.s, puri.port_no);
+					puri.proto, puri.host.len, redact_pii(puri.host.s), puri.port_no);
 		}
 
 		/* mark route hdr as deleted */
@@ -488,7 +489,7 @@ static inline int after_strict(struct sip_msg* _m)
 		} else {
 			if (enable_socket_mismatch_warning)
 				LM_WARN("no socket found to match RR [%d][%.*s:%d]\n",
-					proto, _m->parsed_uri.host.len, _m->parsed_uri.host.s, port);
+					proto, _m->parsed_uri.host.len, redact_pii(_m->parsed_uri.host.s), port);
 		}
 	}
 
@@ -695,7 +696,7 @@ static inline int after_loose(struct sip_msg* _m, int preloaded)
 			} else {
 				if (enable_socket_mismatch_warning)
 					LM_WARN("no socket found to match 2nd RR [%d][%.*s:%d]\n",
-						puri.proto, puri.host.len, puri.host.s, puri.port_no);
+						puri.proto, puri.host.len, redact_pii(puri.host.s), puri.port_no);
 			}
 
 			rt->deleted = 1;

--- a/modules/sipmsgops/list_hdr.c
+++ b/modules/sipmsgops/list_hdr.c
@@ -23,6 +23,7 @@
 #include "../../mem/mem.h"
 #include "../../parser/msg_parser.h"
 #include "../../parser/parse_list_hdr.h"
+#include "../../redact_pii.h"
 
 #include "list_hdr.h"
 
@@ -104,7 +105,7 @@ int list_hdr_has_val(struct sip_msg *msg, int_str_t *match_hdr, str *val)
 		/* parse the body of the header */
 		if (parse_list_hdr( hdr->body.s, hdr->body.len, &lh)!=0) {
 			LM_ERR("failed to parse body <%.*s> as CSV for hdr <%.*s>\n",
-				hdr->body.len, hdr->body.s, hdr->name.len, hdr->name.s);
+				hdr->body.len, redact_pii(hdr->body.s), hdr->name.len, hdr->name.s);
 			return -1;
 		}
 
@@ -278,7 +279,7 @@ int list_hdr_add_val(struct sip_msg *msg, int_str_t *match_hdr, str *val)
 		/* parse the body, to be sure it is valid */
 		if (parse_list_hdr( body.s, body.len, &lh)<0) {
 			LM_ERR("failed to parse body <%.*s> as CSV for hdr <%.*s>\n",
-				body.len, body.s, hdr->name.len, hdr->name.s);
+				body.len, redact_pii(body.s), hdr->name.len, hdr->name.s);
 			return -1;
 		}
 		// TODO - check for duplicates ??
@@ -369,7 +370,7 @@ int list_hdr_remove_val(struct sip_msg *msg, int_str_t *match_hdr, str *val)
 			/* parse the body, to be sure it is valid */
 			if (parse_list_hdr( body.s, body.len, &lh)<0) {
 				LM_ERR("failed to parse body <%.*s> as CSV for hdr <%.*s>\n",
-					body.len, body.s, hdr->name.len, hdr->name.s);
+					body.len, redact_pii(body.s), hdr->name.len, hdr->name.s);
 				return -1;
 			}
 

--- a/modules/sipmsgops/sipmsgops.c
+++ b/modules/sipmsgops/sipmsgops.c
@@ -55,6 +55,7 @@
 #include "../../mod_fix.h"
 #include "../../trim.h"
 #include "../../lib/cJSON.h"
+#include "../../redact_pii.h"
 
 #include "codecs.h"
 #include "list_hdr.h"
@@ -1336,7 +1337,7 @@ static int sip_validate_hdrs(struct sip_msg *msg)
 					/* check enforcements as per RFC3325 */
 					if (parse_uri( to->uri.s, to->uri.len, &uri)<0) {
 						LM_ERR("invalid uri [%.*s] in first [%.*s] value\n",
-							to->uri.len, to->uri.s,
+							to->uri.len, redact_pii(to->uri.s),
 							hf->name.len, hf->name.s);
 						goto failed;
 					}
@@ -1363,7 +1364,7 @@ static int sip_validate_hdrs(struct sip_msg *msg)
 						}
 						if (parse_uri( to->uri.s, to->uri.len, &uri2)<0) {
 							LM_ERR("invalid uri [%.*s] in second [%.*s] "
-								"value\n", to->uri.len, to->uri.s,
+								"value\n", to->uri.len, redact_pii(to->uri.s),
 								hf2->name.len, hf2->name.s);
 							goto failed;
 						}

--- a/modules/siprec/siprec_logic.c
+++ b/modules/siprec/siprec_logic.c
@@ -28,6 +28,7 @@
 #include "siprec_events.h"
 #include "../../mod_fix.h"
 #include "../../error.h"
+#include "../../redact_pii.h"
 
 int srec_dlg_idx;
 struct b2b_api srec_b2b;
@@ -562,7 +563,7 @@ static int srs_send_invite(struct src_sess *sess)
 		pkg_free(ci.extra_headers->s);
 	if (!client) {
 		LM_ERR("cannot start recording with %.*s!\n",
-				ci.req_uri.len, ci.req_uri.s);
+				ci.req_uri.len, redact_pii(ci.req_uri.s));
 		return -1;
 	}
 

--- a/modules/stir_shaken/stir_shaken.c
+++ b/modules/stir_shaken/stir_shaken.c
@@ -79,6 +79,7 @@
 #include "../../mod_fix.h"
 #include "../../data_lump_rpl.h"
 #include "../../mi/mi.h"
+#include "../../redact_pii.h"
 
 #include "stir_shaken.h"
 
@@ -875,7 +876,7 @@ static int get_orig_tn_from_msg(struct sip_msg *msg, str *orig_tn)
 
 	if (parse_uri(body->uri.s, body->uri.len, &parsed_uri) < 0) {
 		LM_ERR("Failed to parse %s URI: %.*s\n", msg->pai ? "PAI" : "From",
-		       body->uri.len, body->uri.s);
+		       body->uri.len, redact_pii(body->uri.s));
 		return -1;
 	}
 
@@ -906,7 +907,7 @@ static int get_dest_tn_from_msg(struct sip_msg *msg, str *dest_tn)
 	body = get_to(msg);
 
 	if (parse_uri(body->uri.s, body->uri.len, &parsed_uri) < 0) {
-		LM_ERR("Failed to parse To URI: %.*s\n", body->uri.len, body->uri.s);
+		LM_ERR("Failed to parse To URI: %.*s\n", body->uri.len, redact_pii(body->uri.s));
 		return -1;
 	}
 

--- a/modules/tls_mgm/tls_domain.c
+++ b/modules/tls_mgm/tls_domain.c
@@ -35,6 +35,7 @@
 
 #include "../../mem/mem.h"
 #include "../../lib/csv.h"
+#include "../../redact_pii.h"
 #include "tls_domain.h"
 #include "tls_params.h"
 #include "api.h"
@@ -619,7 +620,7 @@ static int parse_domain_address(char *val, unsigned int len, struct ip_addr **ip
 	s.len = p - s.s;
 	p++;
 	if ((*ip = str2ip(&s)) == NULL && (*ip = str2ip6(&s)) == NULL) {
-		LM_ERR("[%.*s] is not an ip\n", s.len, s.s);
+		LM_ERR("[%.*s] is not an ip\n", s.len, redact_pii(s.s));
 		goto parse_err;
 	}
 
@@ -634,7 +635,7 @@ static int parse_domain_address(char *val, unsigned int len, struct ip_addr **ip
 	return 0;
 
 parse_err:
-	LM_ERR("invalid TLS domain address [%s]\n", val);
+	LM_ERR("invalid TLS domain address [%s]\n", redact_pii(val));
 	return -1;
 }
 

--- a/modules/tls_openssl/openssl_config.c
+++ b/modules/tls_openssl/openssl_config.c
@@ -29,6 +29,7 @@
 #include <dirent.h>
 
 #include "../../pt.h"
+#include "../../redact_pii.h"
 #include "../tls_mgm/tls_helper.h"
 
 #include "openssl_api.h"
@@ -691,7 +692,7 @@ int openssl_init_tls_dom(struct tls_domain *d, int init_flags)
 			!SSL_CTX_set_max_proto_version(ctx,
 				ssl_versions[d->method_max - 1])) {
 			LM_ERR("cannot enforce ssl version for tls domain '%.*s'\n",
-					d->name.len, ZSW(d->name.s));
+					d->name.len, redact_pii(d->name.s));
 			return -1;
 		}
 	}

--- a/modules/tls_wolfssl/wolfssl_config.c
+++ b/modules/tls_wolfssl/wolfssl_config.c
@@ -24,6 +24,7 @@
 #include <wolfssl/ssl.h>
 #include <wolfssl/error-ssl.h>
 #include <wolfssl/openssl/ec.h>
+#include "../../redact_pii.h"
 
 #include <dirent.h>
 
@@ -478,7 +479,7 @@ int _wolfssl_init_tls_dom(struct tls_domain *d, int init_flags)
 			(wolfSSL_CTX_set_max_proto_version(d->ctx,
 				ssl_versions[d->method_max - 1]) != WOLFSSL_SUCCESS)) {
 			LM_ERR("cannot enforce ssl version for tls domain '%.*s'\n",
-					d->name.len, ZSW(d->name.s));
+					d->name.len, redact_pii(d->name.s));
 			goto end;
 		}
 	}

--- a/modules/tm/tm.c
+++ b/modules/tm/tm.c
@@ -62,6 +62,7 @@
 #include "../../mem/mem.h"
 #include "../../pvar.h"
 #include "../../mod_fix.h"
+#include "../../redact_pii.h"
 
 #include "sip_msg.h"
 #include "h_table.h"
@@ -639,13 +640,13 @@ static int fixup_phostport2proxy(void** param)
 	}
 
 	if (parse_phostport(s.s, s.len, &host.s, &host.len, &port, &proto)!=0){
-		LM_CRIT("invalid parameter <%.*s>\n",s.len, s.s);
+		LM_CRIT("invalid parameter <%.*s>\n",s.len, redact_pii(s.s));
 		return E_UNSPEC;
 	}
 
 	proxy = mk_proxy( &host, port, proto, 0);
 	if (proxy==0) {
-		LM_ERR("failed to resolve <%.*s>\n", host.len, host.s );
+		LM_ERR("failed to resolve <%.*s>\n", host.len, redact_pii(host.s) );
 		return ser_error;
 	}
 	*(param)=proxy;
@@ -1598,7 +1599,7 @@ static int w_t_new_request(struct sip_msg* msg, str *method,
 	if (body!=NULL) {
 		if ( (p=q_memchr(body->s, ' ', body->len))==NULL ) {
 			LM_ERR("Content Type not found in the beginning of body <%.*s>\n",
-				body->len, body->s);
+				body->len, redact_pii(body->s));
 			return -1;
 		}
 		/* build the Content-type header */

--- a/modules/tm/ut.h
+++ b/modules/tm/ut.h
@@ -44,6 +44,7 @@
 #include "../../forward.h"
 #include "../../mem/mem.h"
 #include "../../parser/msg_parser.h"
+#include "../../redact_pii.h"
 
 /* a forced_proto takes precedence if != PROTO_NONE */
 inline static enum sip_protos get_proto(enum sip_protos force_proto,
@@ -77,7 +78,7 @@ inline static struct proxy_l *uri2proxy( str *uri, int forced_proto )
 	enum sip_protos proto;
 
 	if (parse_uri(uri->s, uri->len, &parsed_uri) < 0) {
-		LM_ERR("bad_uri: %.*s\n", uri->len, uri->s );
+		LM_ERR("bad_uri: %.*s\n", uri->len, redact_pii(uri->s) );
 		return 0;
 	}
 
@@ -95,7 +96,7 @@ inline static struct proxy_l *uri2proxy( str *uri, int forced_proto )
 		parsed_uri.maddr_val.len?&parsed_uri.maddr_val:&parsed_uri.host,
 		parsed_uri.port_no, proto, (parsed_uri.type==SIPS_URI_T)?1:0 );
 	if (p == 0) {
-		LM_ERR("bad host name in URI <%.*s>\n", uri->len, ZSW(uri->s));
+		LM_ERR("bad host name in URI <%.*s>\n", uri->len, redact_pii(uri->s));
 		return 0;
 	}
 

--- a/modules/topology_hiding/topo_hiding_logic.c
+++ b/modules/topology_hiding/topo_hiding_logic.c
@@ -27,6 +27,7 @@
 #include "../../ut.h"
 #include "topo_hiding_logic.h"
 #include "th_no_dlg_logic.h"
+#include "../../redact_pii.h"
 
 extern int force_dialog;
 extern struct rr_binds rr_api;
@@ -1024,7 +1025,7 @@ int topo_callid_post_raw(str *data, struct sip_msg* foo)
 	msg.buf=data->s;
 	msg.len=data->len;
 	if (dlg_th_callid_pre_parse(&msg,1) < 0) {
-		LM_ERR("could not parse resulted sip message: %.*s\n", data->len, data->s);
+		LM_ERR("could not parse resulted sip message: %.*s\n", data->len, redact_pii(data->s));
 		goto done;
 	}
 

--- a/modules/tracer/tracer.c
+++ b/modules/tracer/tracer.c
@@ -3296,7 +3296,7 @@ static mi_response_t *sip_trace_mi_dyn(const mi_params_t *params,
 			break;
 		case TYPE_SIP:
 			if (parse_uri(p_uri, uri.len, &elem->elem.el.uri) < 0) {
-				LM_ERR("failed to parse the [%.*s] URI\n", uri.len, p_uri);
+				LM_ERR("failed to parse the [%.*s] URI\n", uri.len, redact_pii(p_uri));
 				goto error;
 			}
 			break;

--- a/modules/usrloc/dlist.c
+++ b/modules/usrloc/dlist.c
@@ -46,6 +46,7 @@
 #include "../../socket_info.h"
 #include "../../parser/parse_rr.h"
 #include "../../parser/parse_uri.h"
+#include "../../redact_pii.h"
 #include "dlist.h"
 #include "udomain.h"           /* new_udomain, free_udomain */
 #include "utime.h"
@@ -300,19 +301,19 @@ static int get_domain_db_ucontacts(udomain_t *d, void *buf, int *len,
 				}
 				if (parse_uri(uri.s, uri.len, &puri) < 0) {
 					LM_ERR("failed to parse path URI of next hop: '%.*s'\n",
-					        p1_len, p1);
+					        p1_len, redact_pii(p1));
 					return -1;
 				}
 			} else if (r_len > 0) { 
 				if (parse_uri(r, r_len, &puri) < 0) {
 					LM_ERR("failed to parse contact of next hop: '%.*s'\n",
-					        r_len, r);
+					        r_len, redact_pii(r));
 					return -1;
 				}
 			} else {
 				if (parse_uri(p, p_len, &puri) < 0) {
 					LM_ERR("failed to parse contact of next hop: '%.*s'\n",
-					        p_len, p);
+					        p_len, redact_pii(p));
 					return -1;
 				}
 			}
@@ -529,7 +530,7 @@ skip_coords:
 		}
 		if (parse_uri(next_hop_uri.s, next_hop_uri.len, &puri) < 0) {
 			LM_ERR("failed to parse URI of next hop: '%.*s'\n",
-				   next_hop_uri.len, next_hop_uri.s);
+				   next_hop_uri.len, redact_pii(next_hop_uri.s));
 			goto out_free;
 		}
 	}

--- a/modules/usrloc/ucontact.c
+++ b/modules/usrloc/ucontact.c
@@ -42,6 +42,7 @@
 #include "../../dprint.h"
 #include "../../db/db.h"
 #include "../../db/db_insertq.h"
+#include "../../redact_pii.h"
 
 #include "ul_mod.h"
 #include "ul_callback.h"
@@ -80,7 +81,7 @@ static int compute_next_hop(ucontact_t *contact)
 		uri = contact->c;
 
 	if (parse_uri(uri.s, uri.len, &puri) < 0) {
-		LM_ERR("failed to parse URI of next hop: '%.*s'\n", uri.len, uri.s);
+		LM_ERR("failed to parse URI of next hop: '%.*s'\n", uri.len, redact_pii(uri.s));
 		return -1;
 	}
 
@@ -123,7 +124,7 @@ new_ucontact(str* _dom, str* _aor, str* _contact, ucontact_info_t* _ci)
 
 	if (parse_uri(_contact->s, _contact->len, &ct_uri) < 0) {
 		LM_ERR("contact [%.*s] is not valid! Will not store it!\n",
-			  _contact->len, _contact->s);
+			  _contact->len, redact_pii(_contact->s));
 		goto out_free;
 	}
 
@@ -353,7 +354,7 @@ int mem_update_ucontact(ucontact_t* _c, ucontact_info_t* _ci)
 
 	if (compute_next_hop(_c) != 0)
 		LM_ERR("failed to resolve next hop. keeping old one - '%.*s'\n",
-		        _c->next_hop.name.len, _c->next_hop.name.s);
+		        _c->next_hop.name.len, redact_pii(_c->next_hop.name.s));
 
 	if (_c->refresh_time)
 		start_refresh_timer(_c);

--- a/modules/usrloc/udomain.c
+++ b/modules/usrloc/udomain.c
@@ -31,6 +31,7 @@
 #include "../../ut.h"
 #include "../../hash_func.h"
 #include "../../cachedb/cachedb.h"
+#include "../../redact_pii.h"
 
 #include "ul_mod.h"            /* usrloc module parameters */
 #include "ul_evi.h"
@@ -538,8 +539,8 @@ int preload_udomain(db_con_t* _c, udomain_t* _d)
 					user.len, user.s, domain);
 				user.s = uri;
 				if (user.s[user.len]!=0) {
-					LM_CRIT("URI '%.*s@%s' longer than %d\n", user.len, user.s,
-							domain,	MAX_URI_SIZE);
+					LM_CRIT("URI '%.*s@%s' longer than %d\n", user.len, redact_pii(user.s),
+							redact_pii(domain),	MAX_URI_SIZE);
 					continue;
 				}
 			}

--- a/modules/usrloc/ul_mod.c
+++ b/modules/usrloc/ul_mod.c
@@ -50,6 +50,7 @@
 #include "../../ut.h"        /* str_init */
 #include "../../ipc.h"
 #include "../../pvar.h"
+#include "../../redact_pii.h"
 
 #include "ul_mod.h"
 #include "dlist.h"           /* register_udomain */
@@ -427,7 +428,7 @@ static void ul_rpc_data_load(int sender_id, void *_)
 	for( ptr=root ; ptr ; ptr=ptr->next) {
 		if (preload_udomain(ul_dbh, ptr->d) < 0) {
 			LM_ERR("failed to preload domain '%.*s'\n",
-				ptr->name.len, ZSW(ptr->name.s));
+				ptr->name.len, redact_pii(ptr->name.s));
 			/* continue with the other ul domains */;
 		}
 	}

--- a/modules/usrloc/urecord.c
+++ b/modules/usrloc/urecord.c
@@ -40,6 +40,7 @@
 #include "../../ut.h"
 #include "../../hash_func.h"
 #include "../../db/db_insertq.h"
+#include "../../redact_pii.h"
 
 #include "ul_mod.h"
 #include "utime.h"
@@ -991,7 +992,7 @@ static inline struct ucontact* contact_params_match(ucontact_t* contacts,
 	str v1, v2;
 
 	if (parse_uri(_c->s, _c->len, &ct) != 0) {
-		LM_ERR("failed to parse Contact: '%.*s'\n", _c->len, _c->s);
+		LM_ERR("failed to parse Contact: '%.*s'\n", _c->len, redact_pii(_c->s));
 		return NULL;
 	}
 
@@ -1001,7 +1002,7 @@ static inline struct ucontact* contact_params_match(ucontact_t* contacts,
 
 		if (parse_uri(contacts->c.s, contacts->c.len, &cti) != 0) {
 			LM_ERR("failed to parse Contact: '%.*s'\n",
-			       contacts->c.len, contacts->c.s);
+			       contacts->c.len, redact_pii(contacts->c.s));
 			return NULL;
 		}
 

--- a/net/proto_tcp/proto_tcp.c
+++ b/net/proto_tcp/proto_tcp.c
@@ -43,6 +43,7 @@
 #include "../../net/net_tcp_dbg.h"
 #include "../../net/proxy_protocol.h"
 #include "../../parser/msg_parser.h"
+#include "../../redact_pii.h"
 
 #include "tcp_common_defs.h"
 #include "proto_tcp_handler.h"
@@ -698,8 +699,8 @@ again:
 	if (req->error!=TCP_REQ_OK){
 		LM_ERR("bad request, state=%d, error=%d "
 				  "buf:\n%.*s\nparsed:\n%.*s\n", req->state, req->error,
-				  (int)(req->pos-req->buf), req->buf,
-				  (int)(req->parsed-req->start), req->start);
+				  (int)(req->pos-req->buf), redact_pii(req->buf),
+				  (int)(req->parsed-req->start), redact_pii(req->start));
 		LM_DBG("- received from: port %d\n", con->rcv.src_port);
 		print_ip("- received from: ip ",&con->rcv.src_ip, "\n");
 		goto error;

--- a/parser/hf.c
+++ b/parser/hf.c
@@ -53,6 +53,7 @@
 #include "parse_fcaps.h"
 #include "parse_security.h"
 
+#include "../redact_pii.h"
 
 /*
  * Frees a hdr_field structure,
@@ -269,6 +270,6 @@ void dump_hdr_field( struct hdr_field* hf )
 {
 	LM_ERR("type=%d, name=%.*s, body=%.*s, parsed=%p, next=%p\n",
 		hf->type, hf->name.len, ZSW(hf->name.s),
-		hf->body.len, ZSW(hf->body.s),
+		hf->body.len, redact_pii(hf->body.s),
 		hf->parsed, hf->next );
 }

--- a/parser/msg_parser.c
+++ b/parser/msg_parser.c
@@ -57,6 +57,7 @@
 #include "parse_uri.h"
 #include "parse_content.h"
 #include "../msg_callbacks.h"
+#include "../redact_pii.h"
 
 #ifdef DEBUG_DMALLOC
 #include <mem/dmalloc.h>
@@ -859,7 +860,7 @@ int parse_msg_opt(char* buf, unsigned int len, struct sip_msg* msg,
 			LM_DBG(" method:  <%.*s>\n",fl->u.request.method.len,
 				ZSW(fl->u.request.method.s));
 			LM_DBG(" uri:     <%.*s>\n",fl->u.request.uri.len,
-				ZSW(fl->u.request.uri.s));
+				redact_pii(fl->u.request.uri.s));
 			LM_DBG(" version: <%.*s>\n",fl->u.request.version.len,
 				ZSW(fl->u.request.version.s));
 			flags=HDR_EOH_F;
@@ -942,7 +943,7 @@ parse_error:
 
 error:
 	/* more debugging, msg->orig is/should be null terminated*/
-	LM_ERR("message=<%.*s>\n", (int)len, ZSW(buf));
+	LM_ERR("message=<%.*s>\n", (int)len, redact_pii(buf));
 	return -1;
 }
 
@@ -1111,7 +1112,7 @@ int set_dst_host_port(struct sip_msg *msg, str *host, str *port)
 		return -1;
 	}
 	if (parse_uri(tmp, len, &uri)<0) {
-		LM_ERR("bad uri <%.*s>, dropping packet\n", len, tmp);
+		LM_ERR("bad uri <%.*s>, dropping packet\n", len, redact_pii(tmp));
 		return -1;
 	}
 	new_uri=pkg_malloc(MAX_URI_SIZE);
@@ -1219,7 +1220,7 @@ int rewrite_ruri(struct sip_msg *msg, str *sval, int ival,
 		len=msg->first_line.u.request.uri.len;
 	}
 	if (parse_uri(tmp, len, &uri)<0){
-		LM_ERR("bad uri <%.*s>, dropping packet\n", len, tmp);
+		LM_ERR("bad uri <%.*s>, dropping packet\n", len, redact_pii(tmp));
 		return -1;
 	}
 

--- a/parser/parse_authenticate.c
+++ b/parser/parse_authenticate.c
@@ -30,6 +30,7 @@
 #include "../ut.h"
 #include "../lib/turbocompare.h"
 #include "../mem/mem.h"
+#include "../redact_pii.h"
 #include "msg_parser.h"
 #include "parse_authenticate.h"
 
@@ -344,7 +345,7 @@ int parse_authenticate_body( str body, struct authenticate_body *auth)
 
 	return ret;
 parse_error:
-	LM_ERR("parse error in <%.*s> around %ld\n", body.len, body.s, (long)(body.len));
+	LM_ERR("parse error in <%.*s> around %ld\n", body.len, redact_pii(body.s), (long)(body.len));
 error:
 	return -1;
 }

--- a/parser/parse_fline.c
+++ b/parser/parse_fline.c
@@ -33,6 +33,7 @@
 #include "parse_methods.h"
 #include "../mem/mem.h"
 #include "../ut.h"
+#include "../redact_pii.h"
 
 /* grammar:
 	request  =  method SP uri SP version CRLF
@@ -1276,7 +1277,7 @@ error:
 		for (t=0; t<offset; t++)
 			if (*(buffer+t)) *(prn+t)=*(buffer+t);
 			else *(prn+t)=248U;
-		LM_ERR("parsed so far: %.*s\n", offset, ZSW(prn) );
+		LM_ERR("parsed so far: %.*s\n", offset, redact_pii(prn) );
 		pkg_free( prn );
 	};
 error1:

--- a/parser/parse_list_hdr.c
+++ b/parser/parse_list_hdr.c
@@ -21,6 +21,7 @@
 #include <ctype.h>
 #include <strings.h>
 #include "../mem/mem.h"
+#include "../redact_pii.h"
 #include "parse_list_hdr.h"
 
 
@@ -100,7 +101,7 @@ int parse_list_hdr(char *body, int len, struct list_hdr **lh)
 
 parse_error:
 	LM_ERR("parse error in list hdr body [%.*s] around position "
-		"%d\n", len, body, (int)(long)(p-body));
+		"%d\n", len, redact_pii(body), (int)(long)(p-body));
 error:
 	free_list_hdr( head );
 	return -1;
@@ -128,7 +129,7 @@ int list_hdr_has_option(struct hdr_field *hdr, str *opt)
 		if (parse_list_hdr( hdr->body.s, hdr->body.len, &lh)!=0) {
 
 			LM_ERR("failed to parse body <%.*s> as CSV for hdr <%.*s>\n",
-				hdr->body.len, hdr->body.s, hdr->name.len, hdr->name.s);
+				hdr->body.len, redact_pii(hdr->body.s), hdr->name.len, hdr->name.s);
 			/* skip this header, try next */
 
 		} else {

--- a/parser/parse_replaces.c
+++ b/parser/parse_replaces.c
@@ -28,6 +28,7 @@
 #include "../ut.h"
 #include "../errinfo.h"
 #include "../mem/mem.h"
+#include "../redact_pii.h"
 #include "parse_replaces.h"
 
 /*
@@ -282,7 +283,7 @@ int parse_replaces_body(char* buf, int buf_len, struct replaces_body* replaces_b
 
 		default:
 			LM_CRIT("bad state %d parsed: <%.*s> (%d) / <%.*s> (%d)\n",
-			state, (int)(p-buf), ZSW(buf), (int)(p-buf), buf_len, ZSW(buf), buf_len);
+			state, (int)(p-buf), redact_pii(ZSW(buf)), (int)(p-buf), buf_len, redact_pii(ZSW(buf)), buf_len);
 			return -1;
 		}
 	}
@@ -335,7 +336,7 @@ int parse_replaces_body(char* buf, int buf_len, struct replaces_body* replaces_b
 
 	default:
 		LM_CRIT("bad state %d parsed: <%.*s> (%d) / <%.*s> (%d)\n",
-			state, (int)(p-buf), ZSW(buf), (int)(p-buf), buf_len, ZSW(buf), buf_len);
+			state, (int)(p-buf), redact_pii(ZSW(buf)), (int)(p-buf), buf_len, redact_pii(ZSW(buf)), buf_len);
 		return -1;
 	}
 

--- a/parser/parse_to.c
+++ b/parser/parse_to.c
@@ -35,6 +35,7 @@
 #include "../ut.h"
 #include "../mem/mem.h"
 #include "../errinfo.h"
+#include "../redact_pii.h"
 
 
 enum {
@@ -479,7 +480,7 @@ endofheader:
 
 parse_error:
 	LM_ERR("unexpected char [%c] in status %d: <<%.*s>> .\n",
-	    tmp < end? *tmp : *(end-1),status, (int)(tmp-buffer), ZSW(buffer));
+	    tmp < end? *tmp : *(end-1),status, (int)(tmp-buffer), redact_pii(ZSW(buffer)));
 error:
 	if (param) pkg_free(param);
 	free_to_params(to_b);
@@ -816,7 +817,7 @@ endofheader:
 
 parse_error:
 	LM_ERR("unexpected char [%c] in status %d: <<%.*s>> .\n",
-	    tmp < end? *tmp : *(end-1), status, (int)(tmp-buffer), buffer);
+	    tmp < end? *tmp : *(end-1), status, (int)(tmp-buffer), redact_pii(buffer));
 error:
 	first_b->error=PARSE_ERROR;
 	free_to_params(first_b);

--- a/parser/parse_via.c
+++ b/parser/parse_via.c
@@ -53,7 +53,7 @@
 #include "../mem/mem.h"
 #include "parse_via.h"
 #include "parse_def.h"
-
+#include "../redact_pii.h"
 
 
 /* main via states (uri:port ...) */
@@ -2260,7 +2260,7 @@ endofpacket:
 		vb->port=str2s(vb->port_str.s, vb->port_str.len, &err);
 		if (err){
 					LM_ERR(" invalid port number <%.*s>\n",
-						vb->port_str.len, ZSW(vb->port_str.s));
+						vb->port_str.len, redact_pii(vb->port_str.s));
 					goto parse_error;
 		}
 	}
@@ -2273,7 +2273,7 @@ nextvia:
 		vb->port=str2s(vb->port_str.s, vb->port_str.len, &err);
 		if (err){
 					LM_ERR(" invalid port number <%.*s>\n",
-						vb->port_str.len, ZSW(vb->port_str.s));
+						vb->port_str.len, redact_pii(vb->port_str.s));
 					goto parse_error;
 		}
 	}
@@ -2289,11 +2289,11 @@ nextvia:
 
 parse_error:
 	if (end>buffer){
-		LM_ERR(" <%.*s>\n", (int)(end-buffer), ZSW(buffer));
+		LM_ERR(" <%.*s>\n", (int)(end-buffer), redact_pii(buffer));
 	}
 	if ((tmp>buffer)&&(tmp<end)){
 		LM_ERR("parsed so far:<%.*s>\n",
-				(int)(tmp-buffer), ZSW(buffer) );
+				(int)(tmp-buffer), redact_pii(buffer) );
 	}else{
 		LM_ERR("via parse failed\n");
 	}

--- a/parser/sdp/sdp_helpr_funcs.c
+++ b/parser/sdp/sdp_helpr_funcs.c
@@ -29,6 +29,7 @@
 
 
 #include "../../ut.h"
+#include "../../redact_pii.h"
 #include "../msg_parser.h"
 #include "../parser_f.h"
 #include "../parse_hname2.h"
@@ -417,7 +418,7 @@ int extract_mediaip(str *body, str *mediaip, int *pf, char *line)
 		cp = eat_space_end(cp + len + 1, mediaip->s + mediaip->len);
 	}
 	if (nextisip != 2 || mediaip->len == 0) {
-		LM_ERR("no `IP[4|6]' in `%s' field\n",line);
+		LM_ERR("no `IP[4|6]' in `%s' field\n",redact_pii(line));
 		return -1;
 	}
 	return 1;

--- a/proxy.c
+++ b/proxy.c
@@ -48,7 +48,7 @@
 #include "resolve.h"
 #include "ip_addr.h"
 #include "globals.h"
-
+#include "redact_pii.h"
 
 struct proxy_l* proxies=0;
 
@@ -216,7 +216,7 @@ struct proxy_l* mk_proxy(str* name, unsigned short port, unsigned short proto,
 	if (!he || !he->h_addr_list[0]) {
 		ser_error=E_BAD_ADDRESS;
 		LM_CRIT("could not resolve hostname: \"%.*s\"%s\n",
-		        name->len, name->s, he ? " (0 results)" : "");
+		        name->len, redact_pii(name->s), he ? " (0 results)" : "");
 		pkg_free(p);
 		goto error;
 	}
@@ -312,7 +312,7 @@ struct proxy_l* mk_shm_proxy(str* name, unsigned short port, unsigned short prot
 		disable_dns_failover?0:&p->dn );
 	if (he==0){
 		ser_error=E_BAD_ADDRESS;
-		LM_CRIT("could not resolve hostname: \"%.*s\"\n", name->len, name->s);
+		LM_CRIT("could not resolve hostname: \"%.*s\"\n", name->len, redact_pii(name->s));
 		shm_free(p);
 		goto error;
 	}

--- a/redact_pii.c
+++ b/redact_pii.c
@@ -1,0 +1,9 @@
+#include <string.h>
+#include "ut.h"
+#include "redact_pii.h"
+
+int redact_pii_ = 0;
+
+inline const char* redact_pii(const char* input) { 
+    return redact_pii_ ? "****" : ZSW(input); 
+}

--- a/redact_pii.c
+++ b/redact_pii.c
@@ -1,9 +1,31 @@
 #include <string.h>
+#include <stdio.h>
 #include "ut.h"
 #include "redact_pii.h"
 
 int redact_pii_ = 0;
+char *redact_template = "****";
+int redact_mode = REDACT_REPLACE;
 
-inline const char* redact_pii(const char* input) { 
-    return redact_pii_ ? "****" : ZSW(input); 
+inline const char* redact_pii(const char* input) {
+    static char buf[512];
+    const char *safe = ZSW(input);
+
+    if (!redact_pii_)
+        return safe;
+
+    switch (redact_mode) {
+    case REDACT_APPEND:
+        snprintf(buf, sizeof(buf), "%s%s", safe, redact_template);
+        return buf;
+    case REDACT_PREPEND:
+        snprintf(buf, sizeof(buf), "%s%s", redact_template, safe);
+        return buf;
+    case REDACT_FORMAT:
+        snprintf(buf, sizeof(buf), redact_template, safe);
+        return buf;
+    case REDACT_REPLACE:
+    default:
+        return redact_template;
+    }
 }

--- a/redact_pii.c
+++ b/redact_pii.c
@@ -57,3 +57,25 @@ inline const char* redact_pii(const char* input) {
 		return redact_template;
 	}
 }
+
+inline int redact_pii_len(const char* input, int orig_len) {
+	size_t tpl_len, input_len;
+
+	if (!redact_pii_)
+		return orig_len;
+
+	switch (redact_mode) {
+	case REDACT_REPLACE:
+		return (int)strlen(redact_template);
+	case REDACT_APPEND:
+		return orig_len + (int)strlen(redact_template);
+	case REDACT_PREPEND:
+		return (int)strlen(redact_template) + orig_len;
+	case REDACT_FORMAT:
+		input_len = input ? strlen(input) : 0;
+		tpl_len = redact_fmt.left.len + input_len + redact_fmt.right.len;
+		return (int)tpl_len;
+	default:
+		return (int)strlen(redact_template);
+	}
+}

--- a/redact_pii.c
+++ b/redact_pii.c
@@ -57,25 +57,3 @@ inline const char* redact_pii(const char* input) {
 		return redact_template;
 	}
 }
-
-inline int redact_pii_len(const char* input, int orig_len) {
-	size_t tpl_len, input_len;
-
-	if (!redact_pii_)
-		return orig_len;
-
-	switch (redact_mode) {
-	case REDACT_REPLACE:
-		return (int)strlen(redact_template);
-	case REDACT_APPEND:
-		return orig_len + (int)strlen(redact_template);
-	case REDACT_PREPEND:
-		return (int)strlen(redact_template) + orig_len;
-	case REDACT_FORMAT:
-		input_len = input ? strlen(input) : 0;
-		tpl_len = redact_fmt.left.len + input_len + redact_fmt.right.len;
-		return (int)tpl_len;
-	default:
-		return (int)strlen(redact_template);
-	}
-}

--- a/redact_pii.c
+++ b/redact_pii.c
@@ -1,31 +1,59 @@
 #include <string.h>
-#include <stdio.h>
 #include "ut.h"
 #include "redact_pii.h"
 
 int redact_pii_ = 0;
 char *redact_template = "****";
 int redact_mode = REDACT_REPLACE;
+redact_log_format_t redact_fmt = {{NULL, 0}, {NULL, 0}};
+
+#define REDACT_BUF_SIZE 512
 
 inline const char* redact_pii(const char* input) {
-    static char buf[512];
-    const char *safe = ZSW(input);
+	static char buf[REDACT_BUF_SIZE];
+	const char *safe = ZSW(input);
+	size_t input_len, idx;
 
-    if (!redact_pii_)
-        return safe;
+	if (!redact_pii_)
+		return safe;
 
-    switch (redact_mode) {
-    case REDACT_APPEND:
-        snprintf(buf, sizeof(buf), "%s%s", safe, redact_template);
-        return buf;
-    case REDACT_PREPEND:
-        snprintf(buf, sizeof(buf), "%s%s", redact_template, safe);
-        return buf;
-    case REDACT_FORMAT:
-        snprintf(buf, sizeof(buf), redact_template, safe);
-        return buf;
-    case REDACT_REPLACE:
-    default:
-        return redact_template;
-    }
+	switch (redact_mode) {
+	case REDACT_REPLACE:
+		return redact_template;
+	case REDACT_APPEND:
+		input_len = strlen(safe);
+		idx = 0;
+		memcpy(buf + idx, safe, input_len);
+		idx += input_len;
+		memcpy(buf + idx, redact_template, strlen(redact_template));
+		idx += strlen(redact_template);
+		buf[idx] = '\0';
+		return buf;
+	case REDACT_PREPEND:
+		input_len = strlen(safe);
+		idx = 0;
+		memcpy(buf + idx, redact_template, strlen(redact_template));
+		idx += strlen(redact_template);
+		memcpy(buf + idx, safe, input_len);
+		idx += input_len;
+		buf[idx] = '\0';
+		return buf;
+	case REDACT_FORMAT:
+		input_len = strlen(safe);
+		idx = 0;
+		if (redact_fmt.left.len > 0) {
+			memcpy(buf + idx, redact_fmt.left.s, redact_fmt.left.len);
+			idx += redact_fmt.left.len;
+		}
+		memcpy(buf + idx, safe, input_len);
+		idx += input_len;
+		if (redact_fmt.right.len > 0) {
+			memcpy(buf + idx, redact_fmt.right.s, redact_fmt.right.len);
+			idx += redact_fmt.right.len;
+		}
+		buf[idx] = '\0';
+		return buf;
+	default:
+		return redact_template;
+	}
 }

--- a/redact_pii.h
+++ b/redact_pii.h
@@ -1,0 +1,25 @@
+/*
+ *
+ * This file is part of opensips, a free SIP server.
+ *
+ * opensips is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * opensips is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+ */
+
+#ifndef redact_pii_h
+#define redact_pii_h
+
+
+const char* redact_pii(const char* input);
+#endif

--- a/redact_pii.h
+++ b/redact_pii.h
@@ -20,6 +20,17 @@
 #ifndef redact_pii_h
 #define redact_pii_h
 
+enum {
+    REDACT_REPLACE = 0,
+    REDACT_APPEND,
+    REDACT_PREPEND,
+    REDACT_FORMAT
+};
+
+extern int redact_pii_;
+extern char *redact_template;
+extern int redact_mode;
 
 const char* redact_pii(const char* input);
+
 #endif

--- a/redact_pii.h
+++ b/redact_pii.h
@@ -40,5 +40,7 @@ extern int redact_mode;
 extern redact_log_format_t redact_fmt;
 
 const char* redact_pii(const char* input);
+int redact_pii_len(const char* input, int orig_len);
+#define REDACT_PII(len, s) redact_pii_len((s), (len)), redact_pii((s))
 
 #endif

--- a/redact_pii.h
+++ b/redact_pii.h
@@ -40,7 +40,5 @@ extern int redact_mode;
 extern redact_log_format_t redact_fmt;
 
 const char* redact_pii(const char* input);
-int redact_pii_len(const char* input, int orig_len);
-#define REDACT_PII(len, s) redact_pii_len((s), (len)), redact_pii((s))
 
 #endif

--- a/redact_pii.h
+++ b/redact_pii.h
@@ -20,6 +20,8 @@
 #ifndef redact_pii_h
 #define redact_pii_h
 
+#include "str.h"
+
 enum {
     REDACT_REPLACE = 0,
     REDACT_APPEND,
@@ -27,9 +29,15 @@ enum {
     REDACT_FORMAT
 };
 
+typedef struct {
+    str left;
+    str right;
+} redact_log_format_t;
+
 extern int redact_pii_;
 extern char *redact_template;
 extern int redact_mode;
+extern redact_log_format_t redact_fmt;
 
 const char* redact_pii(const char* input);
 

--- a/resolve.c
+++ b/resolve.c
@@ -49,6 +49,7 @@
 #include "ip_addr.h"
 #include "globals.h"
 #include "blacklists.h"
+#include "redact_pii.h"
 
 fetch_dns_cache_f *dnscache_fetch_func=NULL;
 put_dns_cache_f *dnscache_put_func=NULL;
@@ -300,7 +301,7 @@ int get_dns_answer(union dns_query *answer,int anslen,char *qname,int qtype,int 
 		switch (type) {
 			case T_PTR:
 				if (strcasecmp(tname, bp) != 0) {
-					LM_ERR("asked for %s, got %s\n",tname,bp);
+					LM_ERR("asked for %s, got %s\n",redact_pii(tname),redact_pii(bp));
 					cp += n;
 					continue;	/* XXX - had_error++ ? */
 				}
@@ -333,7 +334,7 @@ int get_dns_answer(union dns_query *answer,int anslen,char *qname,int qtype,int 
 			case T_A:
 			case T_AAAA:
 				if (strcasecmp(global_he.h_name, bp) != 0) {
-					LM_ERR("asked for %s, got %s\n",global_he.h_name,bp);
+					LM_ERR("asked for %s, got %s\n",redact_pii(global_he.h_name),redact_pii(bp));
 					cp += n;
 					continue; /* XXX - had_error++ ? */
 				}
@@ -451,7 +452,7 @@ query:
 		if (size < 0) {
 			LM_DBG("Domain name not found: %s\n", query_name);
 			if (dnscache_put_func(name,af==AF_INET?T_A:T_AAAA,NULL,0,1,0) < 0)
-				LM_ERR("Failed to store %s - %d in cache\n",name,af);
+				LM_ERR("Failed to store %s - %d in cache\n",redact_pii(name),af);
 			return NULL;
 		}
 
@@ -485,7 +486,7 @@ query:
 			/* No addresses and no CNAME to follow - this is an error */
 			LM_WARN("No addresses and no CNAME for %s\n", query_name);
 			if (dnscache_put_func(name,af==AF_INET?T_A:T_AAAA,NULL,0,1,0) < 0)
-				LM_ERR("Failed to store %s - %d in cache\n",name,af);
+				LM_ERR("Failed to store %s - %d in cache\n",redact_pii(name),af);
 			return NULL;
 		}
 	}
@@ -496,7 +497,7 @@ query:
 	}
 
 	if (dnscache_put_func(name,af==AF_INET?T_A:T_AAAA,&global_he,-1,0,min_ttl) < 0)
-		LM_ERR("Failed to store %s - %d in cache\n",name,af);
+		LM_ERR("Failed to store %s - %d in cache\n",redact_pii(name),af);
 	return &global_he;
 }
 
@@ -1166,7 +1167,7 @@ query:
 		LM_DBG("lookup(%s, %d) failed\n", name, type);
 		if (cache) {
 			if (dnscache_put_func(name,type,NULL,0,1,0) < 0)
-				LM_ERR("Failed to store %s - %d in cache\n",name,type);
+				LM_ERR("Failed to store %s - %d in cache\n",redact_pii(name),type);
 		}
 		goto not_found;
 	}
@@ -1346,7 +1347,7 @@ query:
 
 	if (cache) {
 		if (dnscache_put_func(name,type,head,rdata_buf_len,0,min_ttl) < 0)
-			LM_ERR("Failed to store %s - %d in cache\n",name,type);
+			LM_ERR("Failed to store %s - %d in cache\n",redact_pii(name),type);
 	}
 	return head;
 error_boundary:

--- a/socket_info.c
+++ b/socket_info.c
@@ -59,6 +59,7 @@
 #include "resolve.h"
 #include "name_alias.h"
 #include "net/trans.h"
+#include "redact_pii.h"
 
 #ifdef __OS_linux
 #include <features.h>     /* for GLIBC version testing */
@@ -901,7 +902,7 @@ int fix_socket(struct socket_info_full *sif, int add_aliases)
 	/* get "official hostnames", all the aliases etc. */
 	he=resolvehost(si->name.s,0);
 	if (he==0){
-		LM_ERR("could not resolve %s\n", si->name.s);
+		LM_ERR("could not resolve %s\n", redact_pii(si->name.s));
 		goto error;
 	}
 	/* check if we got the official name */
@@ -1163,7 +1164,7 @@ int fix_socket_list(struct socket_info_full **list)
 		   ){
 			LM_WARN("removing entry %s:%s [%s]:%s\n",
 			    get_proto_name(si->proto), si->name.s,
-			    si->address_str.s, si->port_no_str.s);
+			    redact_pii(si->address_str.s), si->port_no_str.s);
 			l = sif;
 			sif=sif->next;
 			sock_listrm(list, l);

--- a/socket_info.h
+++ b/socket_info.h
@@ -36,6 +36,7 @@
 #include "globals.h"
 #include "net/trans.h"
 #include "ut.h"
+#include "redact_pii.h"
 
 struct last_real_ports {
 	unsigned short local;
@@ -387,16 +388,16 @@ inline static int parse_phostport(char* s, int slen, char** host, int* hlen,
 	}
 	return 0;
 error_brackets:
-	LM_ERR("too many brackets in %s\n", s);
+	LM_ERR("too many brackets in %s\n", redact_pii(s));
 	return -1;
 error_colons:
-	LM_ERR(" too many colons in %s\n", s);
+	LM_ERR(" too many colons in %s\n", redact_pii(s));
 	return -1;
 error_proto:
-	LM_ERR("bad protocol in %s\n", s);
+	LM_ERR("bad protocol in %s\n", redact_pii(s));
 	return -1;
 error_port:
-	LM_ERR("bad port number in %s\n", s);
+	LM_ERR("bad port number in %s\n", redact_pii(s));
 	return -1;
 }
 

--- a/transformations.c
+++ b/transformations.c
@@ -58,6 +58,7 @@
 #include "sha256.h"
 #include "sha512.h"
 #include "time_rec.h"
+#include "redact_pii.h"
 
 #define TR_BUFFER_SIZE 65536
 
@@ -1167,7 +1168,7 @@ int tr_eval_uri(struct sip_msg *msg, tr_param_t *tp, int subtype,
 		if(parse_uri(_tr_uri.s, _tr_uri.len, &_tr_parsed_uri)!=0)
 		{
 			LM_ERR("invalid uri [%.*s]\n", val->rs.len,
-					val->rs.s);
+					redact_pii(val->rs.s));
 			if(_tr_uri_params != NULL)
 			{
 				free_params(_tr_uri_params);
@@ -1370,7 +1371,7 @@ int tr_eval_via(struct sip_msg *msg, tr_param_t *tp, int subtype,
 		parse_via(_tr_via.s, _tr_via.s+_tr_via.len+4, _tr_parsed_via);
 		if(_tr_parsed_via->error != PARSE_OK) {
 			LM_ERR("invalid via [%.*s]\n", val->rs.len,
-					val->rs.s);
+					redact_pii(val->rs.s));
 			goto error;
 		}
 	}
@@ -1984,7 +1985,7 @@ int tr_eval_ip(struct sip_msg *msg, tr_param_t *tp,int subtype,
 			if ( (p_ip=str2ip(&val->rs))==NULL &&
 			(p_ip=str2ip6(&val->rs))==NULL ) {
 				LM_ERR("Invalid input IP address <%.*s>\n",
-					val->rs.len,val->rs.s);
+					val->rs.len,redact_pii(val->rs.s));
 				goto error;
 			}
 			ip = *p_ip;
@@ -2009,7 +2010,7 @@ int tr_eval_ip(struct sip_msg *msg, tr_param_t *tp,int subtype,
 			if ( (p_ip=str2ip(&val->rs))==NULL &&
 			(p_ip=str2ip6(&val->rs))==NULL ) {
 				LM_ERR("Invalid parameter IP address <%.*s>\n",
-					val->rs.len,val->rs.s);
+					val->rs.len,redact_pii(val->rs.s));
 				goto error;
 			}
 			val->rs.s = p+1;

--- a/ut.h
+++ b/ut.h
@@ -39,6 +39,7 @@
 #include "str.h"
 #include "evi/evi_modules.h"
 #include "evi/evi_core.h"
+#include "redact_pii.h"
 
 #include "mem/mem.h"
 #include "mem/shm_mem.h"
@@ -611,7 +612,7 @@ inline static int un_escape(str *user, str *new_user )
 			value=(hi<<4)+lo;
 			if (value < 32 || value > 126) {
 				LM_ERR("non-ASCII escaped character in '%.*s' @ %d\n",
-					user->len, user->s, i );
+					user->len, redact_pii(user->s), i );
 				goto error;
 			}
 			new_user->s[j] = value;
@@ -1447,12 +1448,12 @@ static inline void log_expiry(int time_diff,int expire,
 			LM_WARN("threshold exceeded : tcp took too long : "
 				"con_get=%d, rcv_fd=%d, send=%d. Source : %.*s\n",
 				tcp_timeout_con_get,tcp_timeout_receive_fd,
-				tcp_timeout_send,dbg_len,extra_dbg);
+				tcp_timeout_send,dbg_len,redact_pii(extra_dbg));
 			time_diff = tcp_timeout_send + tcp_timeout_receive_fd +
 				tcp_timeout_con_get;
 		} else
 			LM_WARN("threshold exceeded : %s took too long - %d us."
-					"Source : %.*s\n",func_info,time_diff,dbg_len,extra_dbg);
+					"Source : %.*s\n",func_info,time_diff,dbg_len,redact_pii(extra_dbg));
 
 		if (memcmp(func_info,"msg",3) == 0) {
 			for (i=0;i<LONGEST_ACTION_SIZE;i++) {


### PR DESCRIPTION
Adding a mechanism to override redact pattern with 4 modes: replace|append|prepend|format

PII input: sip:user@domain.com



Mode	Config	Output
replace	redact_pii_ = 1 redact_template = "REDACTED"  redact_mode = "replace" REDACTED

append	redact_pii_ = 1 redact_template = "[PII]" redact_mode = "append"	sip:user@domain.com[PII]

prepend	redact_pii_ = 1 redact_template = "[PII]" redact_mode = "prepend"	[PII]sip:user@domain.com

format	redact_pii_ = 1 redact_template = "GenesysPII<%s>" redact_mode = "format" GenesysPII<sip:user@domain.com>

Default (no template/mode configured): redact_pii_ = 1 → ****

https://inindca.atlassian.net/browse/GCVCALLP-3053