### PR TITLE
Gcvcallp 3053

### DIFF
--- a/cfg.lex
+++ b/cfg.lex
@@ -280,6 +280,8 @@ MCAST_TTL			"mcast_ttl"
 TOS					"tos"
 DISABLE_DNS_FAILOVER  "disable_dns_failover"
 REDACT_PII_ "redact_pii_"
+REDACT_TEMPLATE "redact_template"
+REDACT_MODE "redact_mode"
 DISABLE_DNS_BLACKLIST "disable_dns_blacklist"
 DST_BLACKLIST		"dst_blacklist"
 MAX_WHILE_LOOPS "max_while_loops"
@@ -527,6 +529,10 @@ SPACE		[ ]
 									return DISABLE_DNS_FAILOVER; }
 <INITIAL>{REDACT_PII_}	{	count(); yylval.strval=yytext; 
 									return REDACT_PII_;}
+<INITIAL>{REDACT_TEMPLATE}	{	count(); yylval.strval=yytext;
+									return REDACT_TEMPLATE;}
+<INITIAL>{REDACT_MODE}	{	count(); yylval.strval=yytext;
+									return REDACT_MODE;}
 <INITIAL>{DISABLE_DNS_BLACKLIST}	{	count(); yylval.strval=yytext;
 									return DISABLE_DNS_BLACKLIST; }
 <INITIAL>{DST_BLACKLIST}	{	count(); yylval.strval=yytext;

--- a/cfg.y
+++ b/cfg.y
@@ -1597,17 +1597,18 @@ assign_stm: LOGLEVEL EQUAL snumber { IFOR();
 									}
 		| REDACT_PII_ error { yyerror("boolean value expected"); }
 		| REDACT_TEMPLATE EQUAL STRING { IFOR();
-										redact_template=$3;
+										redact_template.s=$3;
+										redact_template.len=strlen($3);
 										if (redact_mode == REDACT_FORMAT) {
-											char *pct = strstr(redact_template, "%s");
+											char *pct = strstr(redact_template.s, "%s");
 											if (pct) {
-												redact_fmt.left.s = redact_template;
-												redact_fmt.left.len = pct - redact_template;
+												redact_fmt.left.s = redact_template.s;
+												redact_fmt.left.len = pct - redact_template.s;
 												redact_fmt.right.s = pct + 2;
 												redact_fmt.right.len = strlen(pct + 2);
 											} else {
-												redact_fmt.left.s = redact_template;
-												redact_fmt.left.len = strlen(redact_template);
+												redact_fmt.left.s = redact_template.s;
+												redact_fmt.left.len = redact_template.len;
 												redact_fmt.right.s = "";
 												redact_fmt.right.len = 0;
 											}
@@ -1623,16 +1624,16 @@ assign_stm: LOGLEVEL EQUAL snumber { IFOR();
 											redact_mode=REDACT_PREPEND;
 										else if (strcasecmp($3, "format")==0) {
 											redact_mode=REDACT_FORMAT;
-											if (redact_template) {
-												char *pct = strstr(redact_template, "%s");
+											if (redact_template.s) {
+												char *pct = strstr(redact_template.s, "%s");
 												if (pct) {
-													redact_fmt.left.s = redact_template;
-													redact_fmt.left.len = pct - redact_template;
+													redact_fmt.left.s = redact_template.s;
+													redact_fmt.left.len = pct - redact_template.s;
 													redact_fmt.right.s = pct + 2;
 													redact_fmt.right.len = strlen(pct + 2);
 												} else {
-													redact_fmt.left.s = redact_template;
-													redact_fmt.left.len = strlen(redact_template);
+													redact_fmt.left.s = redact_template.s;
+													redact_fmt.left.len = redact_template.len;
 													redact_fmt.right.s = "";
 													redact_fmt.right.len = 0;
 												}

--- a/cfg.y
+++ b/cfg.y
@@ -1598,6 +1598,20 @@ assign_stm: LOGLEVEL EQUAL snumber { IFOR();
 		| REDACT_PII_ error { yyerror("boolean value expected"); }
 		| REDACT_TEMPLATE EQUAL STRING { IFOR();
 										redact_template=$3;
+										if (redact_mode == REDACT_FORMAT) {
+											char *pct = strstr(redact_template, "%s");
+											if (pct) {
+												redact_fmt.left.s = redact_template;
+												redact_fmt.left.len = pct - redact_template;
+												redact_fmt.right.s = pct + 2;
+												redact_fmt.right.len = strlen(pct + 2);
+											} else {
+												redact_fmt.left.s = redact_template;
+												redact_fmt.left.len = strlen(redact_template);
+												redact_fmt.right.s = "";
+												redact_fmt.right.len = 0;
+											}
+										}
 									}
 		| REDACT_TEMPLATE error { yyerror("string value expected"); }
 		| REDACT_MODE EQUAL STRING { IFOR();
@@ -1607,8 +1621,23 @@ assign_stm: LOGLEVEL EQUAL snumber { IFOR();
 											redact_mode=REDACT_APPEND;
 										else if (strcasecmp($3, "prepend")==0)
 											redact_mode=REDACT_PREPEND;
-										else if (strcasecmp($3, "format")==0)
+										else if (strcasecmp($3, "format")==0) {
 											redact_mode=REDACT_FORMAT;
+											if (redact_template) {
+												char *pct = strstr(redact_template, "%s");
+												if (pct) {
+													redact_fmt.left.s = redact_template;
+													redact_fmt.left.len = pct - redact_template;
+													redact_fmt.right.s = pct + 2;
+													redact_fmt.right.len = strlen(pct + 2);
+												} else {
+													redact_fmt.left.s = redact_template;
+													redact_fmt.left.len = strlen(redact_template);
+													redact_fmt.right.s = "";
+													redact_fmt.right.len = 0;
+												}
+											}
+										}
 										else
 											yyerror("redact_mode must be: replace|append|prepend|format");
 									}

--- a/cfg.y
+++ b/cfg.y
@@ -111,6 +111,7 @@
 #include "config.h"
 #include "mem/rpm_mem.h"
 #include "poll_types.h"
+#include "redact_pii.h"
 
 #ifdef SHM_EXTRA_STATS
 #include "mem/module_info.h"
@@ -394,6 +395,8 @@ extern int cfg_parse_only_routes;
 %token TOS
 %token DISABLE_DNS_FAILOVER
 %token REDACT_PII_
+%token REDACT_TEMPLATE
+%token REDACT_MODE
 %token DISABLE_DNS_BLACKLIST
 %token DST_BLACKLIST
 %token DISABLE_STATELESS_FWD
@@ -1592,7 +1595,24 @@ assign_stm: LOGLEVEL EQUAL snumber { IFOR();
 		| REDACT_PII_ EQUAL NUMBER { IFOR();
 										redact_pii_=$3;
 									}
-		| REDACT_PII_ error { yyerror("boolean value expected"); }				
+		| REDACT_PII_ error { yyerror("boolean value expected"); }
+		| REDACT_TEMPLATE EQUAL STRING { IFOR();
+										redact_template=$3;
+									}
+		| REDACT_TEMPLATE error { yyerror("string value expected"); }
+		| REDACT_MODE EQUAL STRING { IFOR();
+										if (strcasecmp($3, "replace")==0)
+											redact_mode=REDACT_REPLACE;
+										else if (strcasecmp($3, "append")==0)
+											redact_mode=REDACT_APPEND;
+										else if (strcasecmp($3, "prepend")==0)
+											redact_mode=REDACT_PREPEND;
+										else if (strcasecmp($3, "format")==0)
+											redact_mode=REDACT_FORMAT;
+										else
+											yyerror("redact_mode must be: replace|append|prepend|format");
+									}
+		| REDACT_MODE error { yyerror("string value expected (replace|append|prepend|format)"); }
 		| DISABLE_DNS_BLACKLIST EQUAL NUMBER { IFOR();
 										disable_dns_blacklist=$3;
 									}

--- a/redact_pii.c
+++ b/redact_pii.c
@@ -21,7 +21,7 @@ redact_log_format_t redact_fmt = {{NULL, 0}, {NULL, 0}};
 	} while (0)
 
 inline const char* redact_pii(const char* input) {
-	static char buf[REDACT_BUF_SIZE];
+	static __thread char buf[REDACT_BUF_SIZE];
 	const char *safe = ZSW(input);
 	size_t input_len = 0; 
 	size_t idx = 0;

--- a/redact_pii.c
+++ b/redact_pii.c
@@ -1,9 +1,31 @@
 #include <string.h>
+#include <stdio.h>
 #include "ut.h"
 #include "redact_pii.h"
 
 int redact_pii_ = 0;
+char *redact_template = "****";
+int redact_mode = REDACT_REPLACE;
 
-inline const char* redact_pii(const char* input) { 
-    return redact_pii_ ? "****" : ZSW(input); 
+inline const char* redact_pii(const char* input) {
+    static char buf[512];
+    const char *safe = ZSW(input);
+
+    if (!redact_pii_)
+        return safe;
+
+    switch (redact_mode) {
+    case REDACT_APPEND:
+        snprintf(buf, sizeof(buf), "%s%s", safe, redact_template);
+        return buf;
+    case REDACT_PREPEND:
+        snprintf(buf, sizeof(buf), "%s%s", redact_template, safe);
+        return buf;
+    case REDACT_FORMAT:
+        snprintf(buf, sizeof(buf), redact_template, safe);
+        return buf;
+    case REDACT_REPLACE:
+    default:
+        return redact_template;
+    }
 }

--- a/redact_pii.c
+++ b/redact_pii.c
@@ -57,3 +57,25 @@ inline const char* redact_pii(const char* input) {
 		return redact_template;
 	}
 }
+
+inline int redact_pii_len(const char* input, int orig_len) {
+	size_t tpl_len, input_len;
+
+	if (!redact_pii_)
+		return orig_len;
+
+	switch (redact_mode) {
+	case REDACT_REPLACE:
+		return (int)strlen(redact_template);
+	case REDACT_APPEND:
+		return orig_len + (int)strlen(redact_template);
+	case REDACT_PREPEND:
+		return (int)strlen(redact_template) + orig_len;
+	case REDACT_FORMAT:
+		input_len = input ? strlen(input) : 0;
+		tpl_len = redact_fmt.left.len + input_len + redact_fmt.right.len;
+		return (int)tpl_len;
+	default:
+		return (int)strlen(redact_template);
+	}
+}

--- a/redact_pii.c
+++ b/redact_pii.c
@@ -57,25 +57,3 @@ inline const char* redact_pii(const char* input) {
 		return redact_template;
 	}
 }
-
-inline int redact_pii_len(const char* input, int orig_len) {
-	size_t tpl_len, input_len;
-
-	if (!redact_pii_)
-		return orig_len;
-
-	switch (redact_mode) {
-	case REDACT_REPLACE:
-		return (int)strlen(redact_template);
-	case REDACT_APPEND:
-		return orig_len + (int)strlen(redact_template);
-	case REDACT_PREPEND:
-		return (int)strlen(redact_template) + orig_len;
-	case REDACT_FORMAT:
-		input_len = input ? strlen(input) : 0;
-		tpl_len = redact_fmt.left.len + input_len + redact_fmt.right.len;
-		return (int)tpl_len;
-	default:
-		return (int)strlen(redact_template);
-	}
-}

--- a/redact_pii.c
+++ b/redact_pii.c
@@ -1,59 +1,56 @@
 #include <string.h>
+#include "str.h"
 #include "ut.h"
 #include "redact_pii.h"
 
 int redact_pii_ = 0;
-char *redact_template = "****";
+str redact_template = str_init("****");
 int redact_mode = REDACT_REPLACE;
 redact_log_format_t redact_fmt = {{NULL, 0}, {NULL, 0}};
 
 #define REDACT_BUF_SIZE 512
+#define SAFE_COPY_TO_BUFFER(_c, _len) \
+	do { \
+		size_t _n = (_len); \
+		if (idx + _n < REDACT_BUF_SIZE) { \
+			memcpy(buf + idx, (_c), _n); \
+			idx += _n; \
+		} else { \
+			goto end; \
+		} \
+	} while (0)
 
 inline const char* redact_pii(const char* input) {
 	static char buf[REDACT_BUF_SIZE];
 	const char *safe = ZSW(input);
-	size_t input_len, idx;
+	size_t input_len = 0; 
+	size_t idx = 0;
 
 	if (!redact_pii_)
 		return safe;
 
+	input_len = strlen(safe);
 	switch (redact_mode) {
-	case REDACT_REPLACE:
-		return redact_template;
 	case REDACT_APPEND:
-		input_len = strlen(safe);
-		idx = 0;
-		memcpy(buf + idx, safe, input_len);
-		idx += input_len;
-		memcpy(buf + idx, redact_template, strlen(redact_template));
-		idx += strlen(redact_template);
-		buf[idx] = '\0';
-		return buf;
+		SAFE_COPY_TO_BUFFER(safe, input_len);
+		SAFE_COPY_TO_BUFFER(redact_template.s, redact_template.len);
+		goto end;
 	case REDACT_PREPEND:
-		input_len = strlen(safe);
-		idx = 0;
-		memcpy(buf + idx, redact_template, strlen(redact_template));
-		idx += strlen(redact_template);
-		memcpy(buf + idx, safe, input_len);
-		idx += input_len;
-		buf[idx] = '\0';
-		return buf;
+		SAFE_COPY_TO_BUFFER(redact_template.s, redact_template.len);
+		SAFE_COPY_TO_BUFFER(safe, input_len);
+		goto end;
 	case REDACT_FORMAT:
-		input_len = strlen(safe);
-		idx = 0;
-		if (redact_fmt.left.len > 0) {
-			memcpy(buf + idx, redact_fmt.left.s, redact_fmt.left.len);
-			idx += redact_fmt.left.len;
-		}
-		memcpy(buf + idx, safe, input_len);
-		idx += input_len;
-		if (redact_fmt.right.len > 0) {
-			memcpy(buf + idx, redact_fmt.right.s, redact_fmt.right.len);
-			idx += redact_fmt.right.len;
-		}
-		buf[idx] = '\0';
-		return buf;
+		if (redact_fmt.left.len > 0)
+			SAFE_COPY_TO_BUFFER(redact_fmt.left.s, redact_fmt.left.len);
+		SAFE_COPY_TO_BUFFER(safe, input_len);
+		if (redact_fmt.right.len > 0)
+			SAFE_COPY_TO_BUFFER(redact_fmt.right.s, redact_fmt.right.len);
+		goto end;
 	default:
-		return redact_template;
+		SAFE_COPY_TO_BUFFER(redact_template.s, redact_template.len);
+		goto end;
 	}
+end:
+	buf[idx] = '\0';
+	return buf;
 }

--- a/redact_pii.c
+++ b/redact_pii.c
@@ -1,31 +1,59 @@
 #include <string.h>
-#include <stdio.h>
 #include "ut.h"
 #include "redact_pii.h"
 
 int redact_pii_ = 0;
 char *redact_template = "****";
 int redact_mode = REDACT_REPLACE;
+redact_log_format_t redact_fmt = {{NULL, 0}, {NULL, 0}};
+
+#define REDACT_BUF_SIZE 512
 
 inline const char* redact_pii(const char* input) {
-    static char buf[512];
-    const char *safe = ZSW(input);
+	static char buf[REDACT_BUF_SIZE];
+	const char *safe = ZSW(input);
+	size_t input_len, idx;
 
-    if (!redact_pii_)
-        return safe;
+	if (!redact_pii_)
+		return safe;
 
-    switch (redact_mode) {
-    case REDACT_APPEND:
-        snprintf(buf, sizeof(buf), "%s%s", safe, redact_template);
-        return buf;
-    case REDACT_PREPEND:
-        snprintf(buf, sizeof(buf), "%s%s", redact_template, safe);
-        return buf;
-    case REDACT_FORMAT:
-        snprintf(buf, sizeof(buf), redact_template, safe);
-        return buf;
-    case REDACT_REPLACE:
-    default:
-        return redact_template;
-    }
+	switch (redact_mode) {
+	case REDACT_REPLACE:
+		return redact_template;
+	case REDACT_APPEND:
+		input_len = strlen(safe);
+		idx = 0;
+		memcpy(buf + idx, safe, input_len);
+		idx += input_len;
+		memcpy(buf + idx, redact_template, strlen(redact_template));
+		idx += strlen(redact_template);
+		buf[idx] = '\0';
+		return buf;
+	case REDACT_PREPEND:
+		input_len = strlen(safe);
+		idx = 0;
+		memcpy(buf + idx, redact_template, strlen(redact_template));
+		idx += strlen(redact_template);
+		memcpy(buf + idx, safe, input_len);
+		idx += input_len;
+		buf[idx] = '\0';
+		return buf;
+	case REDACT_FORMAT:
+		input_len = strlen(safe);
+		idx = 0;
+		if (redact_fmt.left.len > 0) {
+			memcpy(buf + idx, redact_fmt.left.s, redact_fmt.left.len);
+			idx += redact_fmt.left.len;
+		}
+		memcpy(buf + idx, safe, input_len);
+		idx += input_len;
+		if (redact_fmt.right.len > 0) {
+			memcpy(buf + idx, redact_fmt.right.s, redact_fmt.right.len);
+			idx += redact_fmt.right.len;
+		}
+		buf[idx] = '\0';
+		return buf;
+	default:
+		return redact_template;
+	}
 }

--- a/redact_pii.h
+++ b/redact_pii.h
@@ -20,6 +20,17 @@
 #ifndef redact_pii_h
 #define redact_pii_h
 
+enum {
+    REDACT_REPLACE = 0,
+    REDACT_APPEND,
+    REDACT_PREPEND,
+    REDACT_FORMAT
+};
+
+extern int redact_pii_;
+extern char *redact_template;
+extern int redact_mode;
 
 const char* redact_pii(const char* input);
+
 #endif

--- a/redact_pii.h
+++ b/redact_pii.h
@@ -40,5 +40,7 @@ extern int redact_mode;
 extern redact_log_format_t redact_fmt;
 
 const char* redact_pii(const char* input);
+int redact_pii_len(const char* input, int orig_len);
+#define REDACT_PII(len, s) redact_pii_len((s), (len)), redact_pii((s))
 
 #endif

--- a/redact_pii.h
+++ b/redact_pii.h
@@ -40,7 +40,5 @@ extern int redact_mode;
 extern redact_log_format_t redact_fmt;
 
 const char* redact_pii(const char* input);
-int redact_pii_len(const char* input, int orig_len);
-#define REDACT_PII(len, s) redact_pii_len((s), (len)), redact_pii((s))
 
 #endif

--- a/redact_pii.h
+++ b/redact_pii.h
@@ -20,6 +20,8 @@
 #ifndef redact_pii_h
 #define redact_pii_h
 
+#include "str.h"
+
 enum {
     REDACT_REPLACE = 0,
     REDACT_APPEND,
@@ -27,9 +29,15 @@ enum {
     REDACT_FORMAT
 };
 
+typedef struct {
+    str left;
+    str right;
+} redact_log_format_t;
+
 extern int redact_pii_;
 extern char *redact_template;
 extern int redact_mode;
+extern redact_log_format_t redact_fmt;
 
 const char* redact_pii(const char* input);
 

--- a/redact_pii.h
+++ b/redact_pii.h
@@ -35,7 +35,7 @@ typedef struct {
 } redact_log_format_t;
 
 extern int redact_pii_;
-extern char *redact_template;
+extern str redact_template;
 extern int redact_mode;
 extern redact_log_format_t redact_fmt;
 


### PR DESCRIPTION
Adding a mechanism to override redact pattern with 4 modes: replace|append|prepend|format

PII input: sip:[user@domain.com](mailto:user@domain.com)

Mode Config Output
replace redact_pii_ = 1 redact_template = "REDACTED" redact_mode = "replace" REDACTED

append redact_pii_ = 1 redact_template = "[PII]" redact_mode = "append" sip:[user@domain.com](mailto:user@domain.com)[PII]

prepend redact_pii_ = 1 redact_template = "[PII]" redact_mode = "prepend" [PII]sip:[user@domain.com](mailto:user@domain.com)

format redact_pii_ = 1 redact_template = "GenesysPII<%s>" redact_mode = "format" GenesysPIIsip:user@domain.com

Default (no template/mode configured): redact_pii_ = 1 → ****

https://inindca.atlassian.net/browse/GCVCALLP-3053